### PR TITLE
FIX: Fatal error on unknown carrier

### DIFF
--- a/myparcel.php
+++ b/myparcel.php
@@ -3365,7 +3365,7 @@ class MyParcel extends Module
 
         $mcds = MyParcelCarrierDeliverySetting::getByCarrierReference($carrier->id_reference);
 
-        if (Tools::strtoupper($currency->iso_code) === 'EUR'
+        if (!empty($mcds) && Tools::strtoupper($currency->iso_code) === 'EUR'
             && ($mcds->delivery || $mcds->pickup)
         ) {
             return $this->display(__FILE__, 'views/templates/hooks/beforecarrier.tpl');


### PR DESCRIPTION
getByCarrierReference does not always return a valid carrier. This should be checked to prevent a fatal error.