### PR TITLE
Fix e-mail layout for multistore

### DIFF
--- a/classes/MyParcelOrderHistory.php
+++ b/classes/MyParcelOrderHistory.php
@@ -465,19 +465,19 @@ class MyParcelOrderHistory extends MyParcelObjectModel
                     'PS_SHOP_EMAIL',
                     null,
                     null,
-                    Context::getContext()->shop->id
+                    $order->id_shop
                 ),
                 (string) Configuration::get(
                     'PS_SHOP_NAME',
                     null,
                     null,
-                    Context::getContext()->shop->id
+                    $order->id_shop
                 ),
                 null,
                 null,
                 $mailDir,
                 false,
-                Context::getContext()->shop->id
+                $order->id_shop
             );
         }
     }


### PR DESCRIPTION
Hi,

I noticed that in a multistore setup the shipment notifications where send from the main store and not from the multistore where the order was placed from. I've fixed this in my own store bye changing the code from this pull request. Maybe you can validate this solution and merge it?

Cheers.