### PR TITLE
Upgradefile fix

### DIFF
--- a/upgrade/upgrade-1.1.2.php
+++ b/upgrade/upgrade-1.1.2.php
@@ -10,15 +10,14 @@ function upgrade_module_1_1_2(MyParcelBE $module): bool
 {
     $carrier              = Table::withPrefix('carrier');
     $carrierConfiguration = Table::withPrefix(Table::TABLE_CARRIER_CONFIGURATION);
+    
+    $query = "SELECT `carrier`.* FROM $carrier AS `carrier`
+	    LEFT JOIN $carrierConfiguration AS `config` 
+	        ON `carrier`.`id_carrier` = `config`.`id_carrier` 
+	               AND `config`.`name` = 'carrierType'
+	    WHERE `carrier`.`external_module_name` = '" . $module::MODULE_NAME . "'
+	    AND `config`.`id_configuration` IS NULL;";
 
-    $query = <<<SQL
-SELECT carrier.* FROM $carrier AS carrier
-  LEFT JOIN $carrierConfiguration 
-    AS config 
-    ON carrier.id_carrier = config.id_carrier AND config.name = carriertype
-WHERE carrier.external_module_name = {$module::MODULE_NAME}
-AND config.id_configuration IS NULL
-SQL;
 
     foreach (Db::getInstance()
                  ->executeS($query) as $record) {


### PR DESCRIPTION
Impossible to upgrade from 1.0.7 to 1.1.2 because of faulty query.
Fixes wrong query and unknown 'carriertype' in query