### PR TITLE
fix: fix error retrieving delivery settings

### DIFF
--- a/src/DeliverySettings/DeliverySettingsRepository.php
+++ b/src/DeliverySettings/DeliverySettingsRepository.php
@@ -73,7 +73,7 @@ class DeliverySettingsRepository
         self::$deliverySettingsByCartId[$cartId]['deliveryOptions'] = $deliveryOptions;
 
         $extraOptions = [];
-        if (!empty($row['extra_options'])) {
+        if (! empty($row['extra_options'])) {
             $extraOptions = json_decode($row['extra_options'], true);
         }
         self::$deliverySettingsByCartId[$cartId]['extraOptions'] = new ExtraOptions($extraOptions);

--- a/src/DeliverySettings/DeliverySettingsRepository.php
+++ b/src/DeliverySettings/DeliverySettingsRepository.php
@@ -73,7 +73,7 @@ class DeliverySettingsRepository
         self::$deliverySettingsByCartId[$cartId]['deliveryOptions'] = $deliveryOptions;
 
         $extraOptions = [];
-        if (isset($row['extra_options'])) {
+        if (!empty($row['extra_options'])) {
             $extraOptions = json_decode($row['extra_options'], true);
         }
         self::$deliverySettingsByCartId[$cartId]['extraOptions'] = new ExtraOptions($extraOptions);


### PR DESCRIPTION
$row['extra_options'] is altijd gezet en daarom is isset niet juist. De waarde kan wel leeg zijn en dat resulteert in een foutmelding. !empty lost dat op.
https://github.com/myparcelnl/prestashop/issues/95
Na 29 dagen is deze fix nog niet eens in de Develop branche door jullie gezet dus zelf maar een PR aangemaakt. Misschien gaat dat sneller.