### PR TITLE
fix(delivery-options): fix not showing after switching shipping method

### DIFF
--- a/views/js/frontend.js
+++ b/views/js/frontend.js
@@ -102,10 +102,10 @@
   }
 
   /**
-   * @returns {jQuery|null}
+   * @returns {boolean}
    */
-  function getRenderedDeliveryOptions() {
-    return getElement('form.myparcel-delivery-options');
+  function hasUnRenderedDeliveryOptions() {
+    return Boolean(getElement('#myparcel-delivery-options'));
   }
 
   /**
@@ -152,10 +152,10 @@
    *
    */
   function updateDeliveryOptions() {
-    if (getRenderedDeliveryOptions()) {
-      document.dispatchEvent(new Event('myparcel_update_config'));
-    } else {
+    if (hasUnRenderedDeliveryOptions()) {
       document.dispatchEvent(new Event('myparcel_render_delivery_options'));
+    } else {
+      document.dispatchEvent(new Event('myparcel_update_config'));
     }
   }
 


### PR DESCRIPTION
- delivery options would not reappear after being rendered, switching to a shipping method that does not support delivery options, and then switching back to one that does

Resolves #105

Bij het switchen naar een shipping method zonder DO verbergt de DO zichzelf, waardoor de html content verdwijnt. Dan bestaat `form.myparcel-delivery-options` ineens niet meer en werken de oude codes niet...