### PR TITLE
fix: resolve scripts to paths based on site url

### DIFF
--- a/src/Module/Hooks/Helpers/AdminOrderList.php
+++ b/src/Module/Hooks/Helpers/AdminOrderList.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Gett\MyparcelBE\Module\Hooks\Helpers;
 
-use Country;
 use Gett\MyparcelBE\Module\Hooks\AdminPanelRenderService;
 use Gett\MyparcelBE\Service\Concern\HasInstance;
 use Gett\MyparcelBE\Service\ControllerService;
 use Media;
-use MyParcelBE;
 use MyParcelNL\Sdk\src\Support\Arr;
 
 class AdminOrderList extends AbstractAdminOrder
@@ -80,6 +78,7 @@ class AdminOrderList extends AbstractAdminOrder
             'currencySign'   => $this->context->currency->getSign(),
             'dateFormatFull' => $this->context->language->date_format_full,
             'dateFormatLite' => $this->context->language->date_format_lite,
+            'modulePathUri'  => $this->module->getPathUri(),
         ];
     }
 

--- a/src/Module/Hooks/Helpers/AdminOrderList.php
+++ b/src/Module/Hooks/Helpers/AdminOrderList.php
@@ -53,6 +53,27 @@ class AdminOrderList extends AbstractAdminOrder
     }
 
     /**
+     * Fixes route urls for sites that are hosted in a subfolder instead of the root. In the frontend, we create urls
+     * to routers like this: <adminUrl> + <path>. In the case of a site hosted at the root, the parts are "site.com/"
+     * and "<adminFolder>/path/to/controller". This will work when concatenated, but when the site is in a folder we
+     * get this: "site.com/<subfolder>/" + "<subfolder>/<adminFolder>/path/to/controller". A more robust fix would
+     * be to use absolute urls, but PrestaShop made it impossible in their router to generate these. So now we just
+     * remove one of the subfolder paths.
+     *
+     * @param  string $route
+     *
+     * @return string
+     */
+    private function createActionPath(string $route): string
+    {
+        $adminBaseLink = $this->context->link->getAdminBaseLink();
+        $baseUrlParts  = parse_url($adminBaseLink);
+        $routePath     = ControllerService::generateUri($route);
+
+        return str_replace($baseUrlParts['path'], '/', $routePath);
+    }
+
+    /**
      * Actions for doing requests from the admin backoffice.
      *
      * @return array
@@ -63,9 +84,9 @@ class AdminOrderList extends AbstractAdminOrder
         return [
             'adminUrl'           => $this->context->link->getAdminBaseLink(),
             'deliveryOptionsUrl' => $this->context->link->getModuleLink($this->module->name, 'checkout'),
-            'pathLabel'          => ControllerService::generateUri(ControllerService::LABEL),
-            'pathLoading'        => ControllerService::generateUri(ControllerService::LOADING),
-            'pathOrder'          => ControllerService::generateUri(ControllerService::ORDER),
+            'pathLabel'          => $this->createActionPath(ControllerService::LABEL),
+            'pathLoading'        => $this->createActionPath(ControllerService::LOADING),
+            'pathOrder'          => $this->createActionPath(ControllerService::ORDER),
         ];
     }
 

--- a/views/js/admin/src/main.ts
+++ b/views/js/admin/src/main.ts
@@ -1,3 +1,4 @@
+import '@/publicPath';
 import '@/directives';
 import Vue from 'vue';
 import VueCompositionAPI from '@vue/composition-api';

--- a/views/js/admin/src/publicPath.ts
+++ b/views/js/admin/src/publicPath.ts
@@ -1,0 +1,10 @@
+/**
+ * Because sites can be hosted in any nested amount of subfolders on / as well as in the root itself, we can't simply
+ * use a static publicPath configuration in vue.config.js. Using the following variable we can define it dynamically.
+ *
+ * @see https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+__webpack_public_path__ = `${window.MyParcelConfiguration.modulePathUri}views/dist/js/admin/`;

--- a/views/js/admin/types/index.d.ts
+++ b/views/js/admin/types/index.d.ts
@@ -33,6 +33,13 @@ interface MyParcelConfiguration {
   currencySign: string;
   dateFormatFull: DateFormatKey;
   dateFormatLite: DateFormatKey;
+
+  /**
+   * The path from server root to the module. Used to have webpack resolve paths in @/publicPath.ts.
+   *
+   * @example <PrestaShop instance path>/modules/myparcelbe/
+   */
+  modulePathUri: string;
 }
 
 type DateFormat = 'full' | 'lite';

--- a/views/js/admin/vue.config.js
+++ b/views/js/admin/vue.config.js
@@ -10,9 +10,11 @@ module.exports = {
   configureWebpack: (config) => {
     if (process.env.NODE_ENV === 'development') {
       config.devtool = 'eval-source-map';
-      config.output.devtoolModuleFilenameTemplate = (info) => info.resourcePath.match(/^\.\/\S*?\.vue$/)
-        ? `webpack-generated:///${info.resourcePath}?${info.hash}`
-        : `webpack-yourCode:///${info.resourcePath}`;
+      config.output.devtoolModuleFilenameTemplate = (info) => {
+        return info.resourcePath.match(/^\.\/\S*?\.vue$/)
+          ? `webpack-generated:///${info.resourcePath}?${info.hash}`
+          : `webpack-yourCode:///${info.resourcePath}`;
+      };
       config.output.devtoolFallbackModuleFilenameTemplate = 'webpack:///[resource-path]?[hash]';
     }
 
@@ -29,5 +31,4 @@ module.exports = {
   // Output: /<module>/views/dist/js/admin
   outputDir: path.resolve(__dirname, '..', '..', 'dist', 'js', 'admin'),
   assetsDir: '',
-  publicPath: '/modules/myparcelbe/views/dist/js/admin',
 };


### PR DESCRIPTION
- Fixes admin backend not working when PrestaShop is installed in a subdirectory, e.g. mysite.com/subfolder/