### PR TITLE
fix: fix error on install due to usage of `use` in factory closure

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -52,7 +52,7 @@ if (! function_exists('\MyParcelNL\PrestaShop\bootPdk')) {
  */
 function psVersionFactory(array $entries): FactoryDefinitionHelper
 {
-    return factory(function () use ($entries) {
+    return factory(function (array $entries) {
         $psVersion = PdkFacade::get('ps.version');
         $fallback  = Arr::first($entries, static function ($entry) {
             return ! isset($entry['version']);
@@ -71,5 +71,5 @@ function psVersionFactory(array $entries): FactoryDefinitionHelper
         }
 
         return PdkFacade::get($fallback['class']);
-    });
+    })->parameter('entries', $entries);
 }


### PR DESCRIPTION
fixes an error on install with recent prestashop releases caused by the `psVersionFactory`

Fixes #281, Closes INT-695
