### PR TITLE
fix(install): fix error when creating audit table

### DIFF
--- a/src/Database/CreateAuditTableDatabaseMigration.php
+++ b/src/Database/CreateAuditTableDatabaseMigration.php
@@ -28,7 +28,6 @@ final class CreateAuditTableDatabaseMigration extends AbstractDatabaseMigration
             $builder->column('model_identifier', 'VARCHAR(255) NOT NULL');
             $builder->timestamps();
             $builder->primary(['id']);
-            $builder->createdTimestamps();
         });
 
         $this->createIndex($this->getTable(), function (CreateIndexSqlBuilder $builder) {


### PR DESCRIPTION
fixes a duplicate column error when attempting to create the audit database table on install or upgrade, which potentially also blocks other database migrations from being executed

fixes INT-735, #287