### PR TITLE
refactor(logging): include original exception message on flush

### DIFF
--- a/src/Service/PsEntityManagerService.php
+++ b/src/Service/PsEntityManagerService.php
@@ -36,7 +36,10 @@ final class PsEntityManagerService
         try {
             $this->entityManager->flush();
         } catch (Throwable $e) {
-            Logger::error('Failed to flush entity manager', ['trace' => $e->getTrace()]);
+            Logger::error('Failed to flush entity manager', [
+                'trace' => $e->getTrace(),
+                'originalMessage' => $e->getMessage()
+            ]);
 
             throw $e;
         }


### PR DESCRIPTION
Include the original error message when logging errors on EntityManager flush