### PR TITLE
fix: show modal and detail shipping details buttons

### DIFF
--- a/views/js/backend/admin/src/__tests__/PsConceptBoxWrapper.spec.ts
+++ b/views/js/backend/admin/src/__tests__/PsConceptBoxWrapper.spec.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest';
 import {mount} from '@vue/test-utils';
-import {defineComponent, h} from 'vue';
+import {defineComponent} from 'vue';
 import PsConceptBoxWrapper from '../components/pdk/PsConceptBoxWrapper.vue';
 
 const PdkBoxStub = defineComponent({

--- a/views/js/backend/admin/src/__tests__/PsConceptBoxWrapper.spec.ts
+++ b/views/js/backend/admin/src/__tests__/PsConceptBoxWrapper.spec.ts
@@ -1,0 +1,107 @@
+import {describe, it, expect} from 'vitest';
+import {mount} from '@vue/test-utils';
+import {defineComponent, h} from 'vue';
+import PsConceptBoxWrapper from '../components/pdk/PsConceptBoxWrapper.vue';
+
+const PdkBoxStub = defineComponent({
+  name: 'PdkBox',
+  props: ['loading'],
+  template: `
+    <div class="pdk-box" :data-loading="loading">
+      <div v-if="$slots.header" class="pdk-box-header"><slot name="header" /></div>
+      <slot />
+      <div v-if="$slots.footer" class="pdk-box-footer"><slot name="footer" /></div>
+    </div>
+  `,
+});
+
+const PdkButtonGroupStub = defineComponent({
+  name: 'PdkButtonGroup',
+  template: '<div class="pdk-button-group"><slot /></div>',
+});
+
+const ActionButtonStub = defineComponent({
+  name: 'ActionButton',
+  props: ['action'],
+  template: '<button class="action-button" :data-action-id="action?.id" />',
+});
+
+const globalStubs = {
+  global: {
+    stubs: {
+      PdkBox: PdkBoxStub,
+      PdkButtonGroup: PdkButtonGroupStub,
+      ActionButton: ActionButtonStub,
+    },
+  },
+};
+
+function createAction(id: string) {
+  return {id, handler: () => {}} as any;
+}
+
+describe('PsConceptBoxWrapper', () => {
+  it('renders default slot content', () => {
+    const wrapper = mount(PsConceptBoxWrapper, {
+      ...globalStubs,
+      slots: {default: 'Main content'},
+    });
+
+    expect(wrapper.text()).toContain('Main content');
+  });
+
+  it('passes loading prop to PdkBox', () => {
+    const wrapper = mount(PsConceptBoxWrapper, {
+      ...globalStubs,
+      props: {loading: true},
+    });
+
+    expect(wrapper.find('.pdk-box').attributes('data-loading')).toBe('true');
+  });
+
+  it('renders header slot when provided', () => {
+    const wrapper = mount(PsConceptBoxWrapper, {
+      ...globalStubs,
+      slots: {header: '<span>Header text</span>'},
+    });
+
+    expect(wrapper.find('.pdk-box-header').exists()).toBe(true);
+    expect(wrapper.find('.pdk-box-header').text()).toBe('Header text');
+  });
+
+  it('does not render header when slot is not provided', () => {
+    const wrapper = mount(PsConceptBoxWrapper, {
+      ...globalStubs,
+      slots: {default: 'Content only'},
+    });
+
+    expect(wrapper.find('.pdk-box-header').exists()).toBe(false);
+  });
+
+  it('renders action buttons when actions are provided', () => {
+    const actions = [createAction('action-1'), createAction('action-2')];
+
+    const wrapper = mount(PsConceptBoxWrapper, {
+      ...globalStubs,
+      props: {actions},
+    });
+
+    expect(wrapper.find('.pdk-box-footer').exists()).toBe(true);
+    expect(wrapper.find('.pdk-button-group').exists()).toBe(true);
+
+    const buttons = wrapper.findAll('.action-button');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].attributes('data-action-id')).toBe('action-1');
+    expect(buttons[1].attributes('data-action-id')).toBe('action-2');
+  });
+
+  it('does not render footer when actions is empty', () => {
+    const wrapper = mount(PsConceptBoxWrapper, {
+      ...globalStubs,
+      props: {actions: []},
+    });
+
+    expect(wrapper.find('.pdk-box-footer').exists()).toBe(false);
+    expect(wrapper.find('.pdk-button-group').exists()).toBe(false);
+  });
+});

--- a/views/js/backend/admin/src/components/pdk/PsConceptBoxWrapper.vue
+++ b/views/js/backend/admin/src/components/pdk/PsConceptBoxWrapper.vue
@@ -1,0 +1,37 @@
+<template>
+  <PdkBox :loading="loading">
+    <template
+      v-if="$slots.header"
+      #header>
+      <slot name="header" />
+    </template>
+
+    <slot />
+
+    <template
+      v-if="actions?.length"
+      #footer>
+      <PdkButtonGroup>
+        <ActionButton
+          v-for="action in actions"
+          :key="action.id"
+          :action="action" />
+      </PdkButtonGroup>
+    </template>
+  </PdkBox>
+</template>
+
+<script lang="ts" setup>
+import {ActionButton, type ActionDefinition} from '@myparcel-dev/pdk-admin';
+
+withDefaults(
+  defineProps<{
+    actions?: ActionDefinition[];
+    loading?: boolean;
+  }>(),
+  {
+    actions: () => [],
+    loading: false,
+  },
+);
+</script>

--- a/views/js/backend/admin/src/components/pdk/index.ts
+++ b/views/js/backend/admin/src/components/pdk/index.ts
@@ -1,5 +1,7 @@
 export {default as PsCheckboxInput} from './PsCheckboxInput.vue';
 
+export {default as PsConceptBoxWrapper} from './PsConceptBoxWrapper.vue';
+
 export {default as PsDropoffInput} from './PsDropoffInput.vue';
 
 export {default as PsFormGroup} from './PsFormGroup.vue';

--- a/views/js/backend/admin/src/main.ts
+++ b/views/js/backend/admin/src/main.ts
@@ -44,6 +44,7 @@ import {
   PsTriStateInput,
   PsRadioInput,
   PsCheckboxInput,
+  PsConceptBoxWrapper,
   PsDropoffInput,
 } from './components';
 
@@ -54,6 +55,7 @@ window.addEventListener('load', () => {
 
     components: {
       [AdminComponent.Box]: Bootstrap4Box,
+      [AdminComponent.ConceptBoxWrapper]: PsConceptBoxWrapper,
       [AdminComponent.Button]: Bootstrap4Button,
       [AdminComponent.ButtonGroup]: Bootstrap4ButtonGroup,
       [AdminComponent.CheckboxGroup]: DefaultCheckboxGroup,


### PR DESCRIPTION
Uses a box wrapper like our Woocommerce plugin to make sure the modal is scrollable and displays the buttons.

INT-1491
