### PR TITLE
fix: prevent Psr17Factory error in ps 1.7

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -35,7 +35,10 @@ return [
         'PrestaShop',
         'PrestaShopBundle',
         'Doctrine',
-        'Symfony',
+        'Symfony\\Bundle',
+        'Symfony\\Component',
+        'Symfony\\Contracts',
+        'Symfony\\Polyfill',
         'GuzzleHttp',
     ],
 ];


### PR DESCRIPTION
INT-1490

Door alleen symfony namespaces te excluden die PrestaShop werkelijk levert en de rest te scopen voorkomen we dat de Psr17Factory lekt in 1.7 en daar een fout veroorzaakt.

Getest in 1.7.8.11 en 8.2.1
