### PR TITLE
fix: support API identifier lookup for order mode webhooks

### DIFF
--- a/src/Pdk/Order/Repository/PsPdkOrderRepository.php
+++ b/src/Pdk/Order/Repository/PsPdkOrderRepository.php
@@ -16,6 +16,7 @@ use MyParcelNL\Pdk\Storage\MemoryCacheStorage;
 use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
 use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment;
 use MyParcelNL\PrestaShop\Pdk\Base\Adapter\PsAddressAdapter;
+use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
 use MyParcelNL\PrestaShop\Repository\PsOrderShipmentRepository;
 use MyParcelNL\PrestaShop\Service\PsProductService;
 use Order as PsOrder;
@@ -48,6 +49,11 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     private $psOrderShipmentRepository;
 
     /**
+     * @var \MyParcelNL\PrestaShop\Repository\PsOrderDataRepository
+     */
+    private $psOrderDataRepository;
+
+    /**
      * @var \MyParcelNL\PrestaShop\Service\PsProductService
      */
     private PsProductService $psProductService;
@@ -55,6 +61,7 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     /**
      * @param  \MyParcelNL\Pdk\Storage\MemoryCacheStorage                       $storage
      * @param  \MyParcelNL\PrestaShop\Repository\PsOrderShipmentRepository      $psOrderShipmentRepository
+     * @param  \MyParcelNL\PrestaShop\Repository\PsOrderDataRepository          $psOrderDataRepository
      * @param  \MyParcelNL\Pdk\Base\Contract\CurrencyServiceInterface           $currencyService
      * @param  \MyParcelNL\Pdk\App\Order\Contract\PdkProductRepositoryInterface $productRepository
      * @param  \MyParcelNL\PrestaShop\Pdk\Base\Adapter\PsAddressAdapter         $addressAdapter
@@ -64,6 +71,7 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     public function __construct(
         MemoryCacheStorage            $storage,
         PsOrderShipmentRepository     $psOrderShipmentRepository,
+        PsOrderDataRepository         $psOrderDataRepository,
         CurrencyServiceInterface      $currencyService,
         PdkProductRepositoryInterface $productRepository,
         PsAddressAdapter              $addressAdapter,
@@ -72,6 +80,7 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     ) {
         parent::__construct($storage);
         $this->psOrderShipmentRepository = $psOrderShipmentRepository;
+        $this->psOrderDataRepository     = $psOrderDataRepository;
         $this->currencyService           = $currencyService;
         $this->productRepository         = $productRepository;
         $this->addressAdapter            = $addressAdapter;
@@ -116,6 +125,29 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
                 ], $orderData)
             );
         });
+    }
+
+    /**
+     * @param  string $uuid
+     *
+     * @return null|\MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function getByApiIdentifier(string $uuid): ?PdkOrder
+    {
+        $orderData = $this->psOrderDataRepository->findOneByApiIdentifier($uuid);
+
+        if (! $orderData) {
+            return null;
+        }
+
+        try {
+            return $this->get($orderData->getOrderId());
+        } catch (InvalidArgumentException $e) {
+            return null;
+        }
     }
 
     /**

--- a/src/Repository/PsOrderDataRepository.php
+++ b/src/Repository/PsOrderDataRepository.php
@@ -20,6 +20,7 @@ final class PsOrderDataRepository extends AbstractPsObjectRepository
      */
     public function findOneByApiIdentifier(string $apiIdentifier): ?MyparcelnlOrderData
     {
+        // The test repository does not implement Doctrine query builders.
         if (! method_exists($this->entityRepository, 'createQueryBuilder')) {
             return $this
                 ->all()

--- a/src/Repository/PsOrderDataRepository.php
+++ b/src/Repository/PsOrderDataRepository.php
@@ -12,4 +12,28 @@ use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
 final class PsOrderDataRepository extends AbstractPsObjectRepository
 {
     protected $entity = MyparcelnlOrderData::class;
+
+    /**
+     * @param  string $apiIdentifier
+     *
+     * @return null|\MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData
+     */
+    public function findOneByApiIdentifier(string $apiIdentifier): ?MyparcelnlOrderData
+    {
+        if (! method_exists($this->entityRepository, 'createQueryBuilder')) {
+            return $this
+                ->all()
+                ->first(static function (MyparcelnlOrderData $orderData) use ($apiIdentifier): bool {
+                    return ($orderData->getData()['apiIdentifier'] ?? null) === $apiIdentifier;
+                });
+        }
+
+        return $this->entityRepository
+            ->createQueryBuilder('orderData')
+            ->where('orderData.data LIKE :apiIdentifier')
+            ->setParameter('apiIdentifier', sprintf('%%"apiIdentifier":%s%%', json_encode($apiIdentifier)))
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
@@ -11,6 +11,8 @@ use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Tests\Factory\Collection\FactoryCollection;
+use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
 use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
 use Order;
 use OrderFactory;
@@ -68,4 +70,54 @@ it('creates a pdk order from order id', function () {
     $pdkOrder = $orderRepository->get($psOrder->id);
 
     expect($pdkOrder)->toBeInstanceOf(PdkOrder::class);
+});
+
+it('finds a pdk order by api identifier', function () {
+    /** @var Order $psOrder */
+    $psOrder = psFactory(Order::class)->store();
+
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId((int) $psOrder->id)
+            ->withData(json_encode(['apiIdentifier' => 'api-uuid-string'])),
+    ]))->store();
+
+    /** @var \MyParcelNL\PrestaShop\Pdk\Order\Repository\PsPdkOrderRepository $orderRepository */
+    $orderRepository = Pdk::get(PsPdkOrderRepository::class);
+
+    $pdkOrder = $orderRepository->getByApiIdentifier('api-uuid-string');
+
+    expect($pdkOrder)
+        ->toBeInstanceOf(PdkOrder::class)
+        ->and((int) $pdkOrder->externalIdentifier)
+        ->toBe((int) $psOrder->id);
+});
+
+it('returns null when api identifier is unknown', function () {
+    /** @var Order $psOrder */
+    $psOrder = psFactory(Order::class)->store();
+
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId((int) $psOrder->id)
+            ->withData(json_encode(['apiIdentifier' => 'another-api-uuid'])),
+    ]))->store();
+
+    /** @var \MyParcelNL\PrestaShop\Pdk\Order\Repository\PsPdkOrderRepository $orderRepository */
+    $orderRepository = Pdk::get(PsPdkOrderRepository::class);
+
+    expect($orderRepository->getByApiIdentifier('missing-api-uuid'))->toBeNull();
+});
+
+it('returns null when api identifier belongs to a missing order', function () {
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId(404)
+            ->withData(json_encode(['apiIdentifier' => 'api-uuid-string'])),
+    ]))->store();
+
+    /** @var \MyParcelNL\PrestaShop\Pdk\Order\Repository\PsPdkOrderRepository $orderRepository */
+    $orderRepository = Pdk::get(PsPdkOrderRepository::class);
+
+    expect($orderRepository->getByApiIdentifier('api-uuid-string'))->toBeNull();
 });


### PR DESCRIPTION
Adds a PrestaShop-specific API identifier lookup for PDK orders.

This is needed for the PDK shipment webhook flow in Order v1 mode, where incoming webhook payloads contain the API `order_id` and the PDK needs to resolve that back to the local PrestaShop order.

## Changes

- Add `findOneByApiIdentifier()` to `PsOrderDataRepository`
- Resolve the API identifier through the database query instead of loading all stored order data into memory
- Add `getByApiIdentifier()` to `PsPdkOrderRepository`
- Add tests for:
  - matching an existing API identifier
  - unknown API identifier
  - order data pointing to a missing PrestaShop order

INT-1536
INT-1537