### PR TITLE
feat(migration): read default carrier from Shop in legacy migration

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -904,12 +904,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "5ef7c12013af2d09c643748ad9424229c94da093"
+                "reference": "0839b492bbe1fbb3fe4c31c8029b24a6ee931d6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/5ef7c12013af2d09c643748ad9424229c94da093",
-                "reference": "5ef7c12013af2d09c643748ad9424229c94da093",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/0839b492bbe1fbb3fe4c31c8029b24a6ee931d6f",
+                "reference": "0839b492bbe1fbb3fe4c31c8029b24a6ee931d6f",
                 "shasum": ""
             },
             "require": {
@@ -918,7 +918,7 @@
                 "fruitcake/php-cors": "^1.2",
                 "justinrainbow/json-schema": "^5.2",
                 "league/openapi-psr7-validator": "^0.22.0",
-                "myparcelnl/sdk": "^11.0.0-beta.1",
+                "myparcelnl/sdk": "^11.0.0-beta.19@beta",
                 "php": ">=7.4.0",
                 "php-di/php-di": "^6.0.0",
                 "psr/log": "^1.0.0 || ^2.0.0 || ^3.0.0",
@@ -961,20 +961,20 @@
                 "issues": "https://github.com/myparcelnl/pdk/issues",
                 "source": "https://github.com/myparcelnl/pdk/tree/v4-capabilities"
             },
-            "time": "2026-05-19T10:46:53+00:00"
+            "time": "2026-05-21T15:15:51+00:00"
         },
         {
             "name": "myparcelnl/sdk",
-            "version": "11.0.0-beta.18",
+            "version": "11.0.0-beta.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/sdk.git",
-                "reference": "a834d606bbb2ee8b51d87f68c07ad1aa1ca23e2e"
+                "reference": "1a3baf80d5cb7e93c71d3888350f05c13930a797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/sdk/zipball/a834d606bbb2ee8b51d87f68c07ad1aa1ca23e2e",
-                "reference": "a834d606bbb2ee8b51d87f68c07ad1aa1ca23e2e",
+                "url": "https://api.github.com/repos/myparcelnl/sdk/zipball/1a3baf80d5cb7e93c71d3888350f05c13930a797",
+                "reference": "1a3baf80d5cb7e93c71d3888350f05c13930a797",
                 "shasum": ""
             },
             "require": {
@@ -1025,9 +1025,9 @@
             ],
             "support": {
                 "issues": "https://github.com/myparcelnl/sdk/issues",
-                "source": "https://github.com/myparcelnl/sdk/tree/v11.0.0-beta.18"
+                "source": "https://github.com/myparcelnl/sdk/tree/v11.0.0-beta.19"
             },
-            "time": "2026-05-15T14:57:32+00:00"
+            "time": "2026-05-21T10:27:10+00:00"
         },
         {
             "name": "php-di/invoker",
@@ -2451,16 +2451,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.45",
+            "version": "v5.4.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e"
+                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a454d47278cc16a5db371fe73ae66a78a633371e",
-                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
+                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
                 "shasum": ""
             },
             "require": {
@@ -2506,7 +2506,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.45"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.52"
             },
             "funding": [
                 {
@@ -2518,11 +2518,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-05-15T06:40:16+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Migration/Pdk/PdkDeliveryOptionsMigration.php
+++ b/src/Migration/Pdk/PdkDeliveryOptionsMigration.php
@@ -6,9 +6,8 @@ namespace MyParcelNL\PrestaShop\Migration\Pdk;
 
 use Generator;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Facade\AccountSettings;
 use MyParcelNL\Pdk\Facade\Logger;
-use MyParcelNL\Pdk\Facade\Pdk;
-use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\PrestaShop\Facade\EntityManager;
 use MyParcelNL\PrestaShop\Migration\AbstractPsMigration;
@@ -78,11 +77,10 @@ final class PdkDeliveryOptionsMigration extends AbstractPsPdkMigration
      */
     private function getDeliveryOptionsTransformationMap(): Generator
     {
-        $propositionService = Pdk::get(PropositionService::class);
         yield new MigratableValue(
             'carrier',
             DeliveryOptions::CARRIER,
-            new TransformValue(function ($value) use ($propositionService) {
+            new TransformValue(function ($value) {
                 $legacyNames = array_values(Carrier::CARRIER_NAME_TO_LEGACY_MAP);
 
                 if (in_array($value, $legacyNames, true)) {
@@ -90,9 +88,14 @@ final class PdkDeliveryOptionsMigration extends AbstractPsPdkMigration
                 }
 
                 try {
-                    $defaultCarrier = $propositionService->getDefaultCarrier();
+                    $shop           = AccountSettings::getShop();
+                    $defaultCarrier = $shop ? $shop->defaultCarrier : null;
 
-                    return Carrier::CARRIER_NAME_TO_LEGACY_MAP[$defaultCarrier->carrier] ?? $value;
+                    if ($defaultCarrier === null) {
+                        return $value;
+                    }
+
+                    return Carrier::CARRIER_NAME_TO_LEGACY_MAP[$defaultCarrier] ?? $value;
                 } catch (\Throwable $e) {
                     return $value;
                 }


### PR DESCRIPTION
## Summary

`PdkDeliveryOptionsMigration`'s legacy-carrier transform previously called `PropositionService::getDefaultCarrier()` as a fallback when the stored carrier wasn't a known legacy name. The PDK has removed that method (INT-1479) — the default carrier now lives on the Shop model.

Read from `AccountSettings::getShop()->defaultCarrier` directly, then map the V2 name back to a legacy name via the existing `Carrier::CARRIER_NAME_TO_LEGACY_MAP`. When the shop has no default configured, fall back to the original `$value` (unchanged behaviour when the fallback is absent).

## Companion

Stacked on top of [myparcelnl/pdk#472 (INT-1479)](https://github.com/myparcelnl/pdk/pull/472), which deletes `PropositionService::getDefaultCarrier()` and migrates all five PDK callers to read from `Shop`. The JS-PDK admin app (shared with WooCommerce) has its own companion: [myparcelnl/js-pdk#344](https://github.com/myparcelnl/js-pdk/pull/344).

Targets `capabilities` (cleanup-compat was already merged in). Flips to ready after the PDK PR merges and the plugin's PDK pin moves forward.

## Changes

- Drop `PropositionService` + `Pdk` imports.
- Replace the `\$propositionService->getDefaultCarrier()` call with `AccountSettings::getShop()->defaultCarrier`.
- Map the V2 name through `Carrier::CARRIER_NAME_TO_LEGACY_MAP` (same mapping the surrounding code already uses).

## Test plan

- [ ] `docker compose run --rm php composer test` against the existing `PdkDeliveryOptionsMigrationTest` cases (test setup already provisions a shop with `defaultCarrier = POSTNL`).
- [ ] After PDK pin moves: smoke test the upgrade migration with legacy delivery-options data that uses non-legacy carrier names.

Resolves INT-1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)