### PR TITLE
fix(checkout): destination-filter carriers via existing capabilities API (INT-1597)

### DIFF
--- a/src/Hooks/HasPsCarrierListHooks.php
+++ b/src/Hooks/HasPsCarrierListHooks.php
@@ -100,7 +100,9 @@ trait HasPsCarrierListHooks
         $repository = Pdk::get(CarrierCapabilitiesRepository::class);
 
         try {
-            $capabilities = $repository->getCapabilitiesForRecipientCountry($countryIso);
+            $capabilities = $repository->getCapabilities([
+                'recipient' => ['country_code' => $countryIso],
+            ]);
         } catch (Throwable $exception) {
             Logger::error('Failed to fetch carrier capabilities for country.', [
                 'country' => $countryIso,

--- a/tests/Unit/Hooks/HasPsCarrierListHooksTest.php
+++ b/tests/Unit/Hooks/HasPsCarrierListHooksTest.php
@@ -39,12 +39,16 @@ class WithHasPsCarrierListHooks
 }
 
 /**
- * Build a CarrierCapabilitiesRepository test double whose `getCapabilitiesForRecipientCountry()`
- * returns one stub object per V2 carrier name. The hook only reads `getCarrier()` on the result.
+ * Build a CarrierCapabilitiesRepository test double that overrides the real public API
+ * (`getCapabilities(array $args): array`). Records the args of the most recent call so
+ * tests can assert the hook passes the cart's destination country. The hook only reads
+ * `getCarrier()` on each returned item.
  */
 function fakeCapabilitiesRepositoryReturning(array $v2CarrierNames): CarrierCapabilitiesRepository
 {
     return new class($v2CarrierNames) extends CarrierCapabilitiesRepository {
+        public array  $lastArgs = [];
+        public int    $callCount = 0;
         private array $v2CarrierNames;
 
         public function __construct(array $v2CarrierNames)
@@ -52,8 +56,11 @@ function fakeCapabilitiesRepositoryReturning(array $v2CarrierNames): CarrierCapa
             $this->v2CarrierNames = $v2CarrierNames;
         }
 
-        public function getCapabilitiesForRecipientCountry(string $cc): array
+        public function getCapabilities(array $args): array
         {
+            $this->callCount++;
+            $this->lastArgs = $args;
+
             return array_map(static function (string $name) {
                 return new class($name) {
                     private string $name;
@@ -72,7 +79,7 @@ function fakeCapabilitiesRepositoryThrowing(): CarrierCapabilitiesRepository
 
         public function __construct() {}
 
-        public function getCapabilitiesForRecipientCountry(string $cc): array
+        public function getCapabilities(array $args): array
         {
             $this->callCount++;
             throw new RuntimeException('Capabilities API returned 503');
@@ -244,6 +251,24 @@ it('keeps all carriers (fail-open) and logs an error when the capabilities call 
         });
 
         expect($errorLogs)->not->toBeEmpty();
+    } finally {
+        $reset();
+    }
+});
+
+it('forwards the cart delivery country to the capabilities API', function () {
+    [$params] = setupModuleWithMappings([RefCapabilitiesSharedCarrierV2::POSTNL], 'BE');
+
+    $fake  = fakeCapabilitiesRepositoryReturning([RefCapabilitiesSharedCarrierV2::POSTNL]);
+    $reset = mockPdkProperty(CarrierCapabilitiesRepository::class, $fake);
+
+    try {
+        (new WithHasPsCarrierListHooks())->hookActionFilterDeliveryOptionList($params);
+
+        expect($fake->callCount)->toBe(1);
+        expect($fake->lastArgs)->toHaveKey('recipient');
+        expect($fake->lastArgs['recipient'])->toHaveKey('country_code');
+        expect($fake->lastArgs['recipient']['country_code'])->toBe('BE');
     } finally {
         $reset();
     }


### PR DESCRIPTION
## Summary
- Fixes INT-1597 — PrestaShop checkout's carrier list isn't filtered by destination.
- Root cause: `HasPsCarrierListHooks::getSupportedCarriersForCountry()` called `CarrierCapabilitiesRepository::getCapabilitiesForRecipientCountry()`, a method that the [2026-05-06 design spec](../blob/capabilities/docs/superpowers/plans/2026-05-06-countries-per-carrier-replacement.md) assumed would land in PDK but [never did on `v4-capabilities`](https://github.com/myparcelnl/pdk/blob/v4-capabilities/src/Carrier/Repository/CarrierCapabilitiesRepository.php). At runtime PHP raised an undefined-method `Error` which the fail-open `catch (Throwable)` swallowed, so every MyParcel-mapped carrier stayed visible for every destination.
- Switched the hook to the real public API `getCapabilities(['recipient' => ['country_code' => $iso]])` — same return shape (`RefCapabilitiesResponseCapabilityV2[]`, each with `getCarrier()`), no PDK change needed.
- Rebound the existing unit-test fakes to override the actual public method on `CarrierCapabilitiesRepository`, and added a test asserting the cart destination ISO is forwarded in the request args. Without this the mocks could drift away from the real surface again silently — that's how the bug shipped in the first place.

## Test plan
- [x] `docker compose run --rm test vendor/bin/pest tests/Unit/Hooks` — 14/14 green
- [ ] Manual checkout smoke: add product, set Belgian address, confirm BE-only carriers stay visible and NL-only carriers disappear; switch to a non-EU country, confirm carriers without that country in capabilities disappear

## Out of scope
- WooCommerce `capabilities` branch — verified there's no analogous `actionFilterDeliveryOptionList` hook (WC uses zone-based filtering in core), so no parallel fix needed.
- PDK — no method added; `v4-capabilities` HEAD already exposes everything we need.

Resolves INT-1597