### PR TITLE
feat(perf): improve the performance of the order grid when loading many orders

### DIFF
--- a/src/Contract/PsObjectRepositoryInterface.php
+++ b/src/Contract/PsObjectRepositoryInterface.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 
 namespace MyParcelNL\PrestaShop\Contract;
 
+use MyParcelNL\Pdk\Base\Support\Collection;
+
 interface PsObjectRepositoryInterface
 {
+    /**
+     * Fetch records by their identifier. Following Laravel's findMany() convention, an empty id set
+     * returns an empty collection (never "all") — use all() to retrieve everything.
+     *
+     * @param  int[] $ids
+     *
+     * @return \MyParcelNL\Pdk\Base\Support\Collection
+     */
+    public function findAll(array $ids = []): Collection;
 }

--- a/src/Hooks/HasPdkOrderGridHooks.php
+++ b/src/Hooks/HasPdkOrderGridHooks.php
@@ -55,11 +55,13 @@ trait HasPdkOrderGridHooks
 
         // Amend the record collection with myparcel data.
         $params['presented_grid']['data']['records'] = new RecordCollection(
-            array_map(static function (array $row) use ($pdkOrders, $repository) {
+            array_map(static function (array $row) use ($pdkOrders) {
                 // Find the specific order in the already loaded collection of pdk orders, so we don't have to load it again.
-                $order = $pdkOrders->firstWhere('externalIdentifier', (string) $row['id_order']);
+                $order = $pdkOrders->firstWhere('externalIdentifier', (int) $row['id_order']);
 
-                $row['myparcel'] = Frontend::renderOrderListItem($order);
+                if ($order) {
+                    $row['myparcel'] = Frontend::renderOrderListItem($order);
+                }
 
                 return $row;
             }, $params['presented_grid']['data']['records']->all())

--- a/src/Hooks/HasPdkOrderGridHooks.php
+++ b/src/Hooks/HasPdkOrderGridHooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MyParcelNL\PrestaShop\Hooks;
 
 use MyParcelNL;
+use MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
 use MyParcelNL\Pdk\Facade\Frontend;
 use MyParcelNL\Pdk\Facade\Language;
@@ -47,11 +48,16 @@ trait HasPdkOrderGridHooks
      */
     public function hookActionOrderGridPresenterModifier(array &$params): void
     {
+        /** @var PdkOrderRepositoryInterface $repository */
+        $repository = Pdk::get(PdkOrderRepositoryInterface::class);
+        /** @var PdkOrderCollection $pdkOrders */
+        $pdkOrders = $repository->fromOrderGridCollection($params['presented_grid']['data']['records']);
+
+        // Amend the record collection with myparcel data.
         $params['presented_grid']['data']['records'] = new RecordCollection(
-            array_map(static function (array $row) {
-                /** @var PdkOrderRepositoryInterface $repository */
-                $repository = Pdk::get(PdkOrderRepositoryInterface::class);
-                $order      = $repository->get($row['id_order']);
+            array_map(static function (array $row) use ($pdkOrders, $repository) {
+                // Find the specific order in the already loaded collection of pdk orders, so we don't have to load it again.
+                $order = $pdkOrders->firstWhere('externalIdentifier', (string) $row['id_order']);
 
                 $row['myparcel'] = Frontend::renderOrderListItem($order);
 

--- a/src/Pdk/Order/Repository/PsPdkOrderRepository.php
+++ b/src/Pdk/Order/Repository/PsPdkOrderRepository.php
@@ -6,22 +6,28 @@ namespace MyParcelNL\PrestaShop\Pdk\Order\Repository;
 
 use InvalidArgumentException;
 use MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection;
+use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
 use MyParcelNL\Pdk\App\Order\Contract\PdkProductRepositoryInterface;
 use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
 use MyParcelNL\Pdk\App\Order\Repository\AbstractPdkOrderRepository;
 use MyParcelNL\Pdk\Base\Contract\CurrencyServiceInterface;
+use MyParcelNL\Pdk\Base\Exception\ModelNotFoundException;
 use MyParcelNL\Pdk\Base\Support\Collection;
+use MyParcelNL\Pdk\Base\Support\Utils;
 use MyParcelNL\Pdk\Shipment\Model\Shipment;
 use MyParcelNL\Pdk\Storage\MemoryCacheStorage;
 use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
+use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
 use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment;
 use MyParcelNL\PrestaShop\Pdk\Base\Adapter\PsAddressAdapter;
 use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
 use MyParcelNL\PrestaShop\Repository\PsOrderShipmentRepository;
 use MyParcelNL\PrestaShop\Service\PsProductService;
 use Order as PsOrder;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShopCollection;
 
-final class PsPdkOrderRepository extends AbstractPdkOrderRepository
+final class PsPdkOrderRepository extends AbstractPdkOrderRepository implements PdkOrderRepositoryInterface
 {
     /**
      * @var \MyParcelNL\Pdk\App\Order\Contract\PdkProductRepositoryInterface
@@ -89,6 +95,13 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     }
 
     /**
+     * Build a single, fully-detailed PdkOrder from a PrestaShop order (id or model).
+     *
+     * Intended for the order detail / export flows where the full order is needed. Loads the
+     * PrestaShop order model for its base fields (addresses, lines, prices) and merges in the
+     * MyParcel-managed data and shipments via the shared assembler. Result is memoized per order
+     * id through retrieve(). Throws when the order does not exist; use find() for a null-safe lookup.
+     *
      * @param  string|int|PsOrder $input
      *
      * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
@@ -98,33 +111,135 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
      */
     public function get($input): PdkOrder
     {
-        if (! $this->psOrderService->exists($input)) {
-            throw new InvalidArgumentException('Order not found');
-        }
-
         /** @var \Order $psOrder */
         $psOrder = $this->psOrderService->get($input);
 
-        return $this->retrieve((string) $psOrder->id, function () use ($psOrder) {
-            $orderData     = $this->psOrderService->getOrderData($psOrder);
-            $orderProducts = new Collection($psOrder->getProducts() ?: []);
+        if (! $psOrder) {
+            throw new InvalidArgumentException('Order not found');
+        }
 
-            return new PdkOrder(
-                array_replace([
-                    'externalIdentifier'  => $psOrder->id,
-                    'shippingAddress'     => $this->addressAdapter->fromOrder($psOrder, 'shipping'),
-                    'billingAddress'      => $this->addressAdapter->fromOrder($psOrder, 'billing'),
-                    'shipments'           => $this->getShipments($psOrder),
-                    'referenceIdentifier' => $psOrder->reference,
-                    'shipmentPrice'       => $this->currencyService->convertToCents($psOrder->total_shipping_tax_incl),
-                    'shipmentVat'         => $this->currencyService->convertToCents($psOrder->total_shipping_tax_excl),
-                    'lines'               => $this->createOrderLines($orderProducts),
-                    'invoiceId'           => $psOrder->id,
-                    'invoiceDate'         => $psOrder->date_add,
-                    'paymentMethod'       => $psOrder->payment,
-                ], $orderData)
+        return $this->retrieve((string) $psOrder->id, function () use ($psOrder) {
+            return $this->assembleOrder(
+                $this->baseFromOrder($psOrder),
+                $this->psOrderService->getOrderData($psOrder),
+                ['shipments' => $this->getShipments($psOrder)]
             );
         });
+    }
+
+    /**
+     * Get multiple items by their identifier,
+     * proxies to findAll() for backward compatibility until getMany() is removed in favor of findAll()
+     * in the next major version.
+     *
+     * @param string|string[] $orderIds
+     * @return PdkOrderCollection
+     */
+    public function getMany($orderIds): PdkOrderCollection
+    {
+        return $this->findAll(Utils::toArray($orderIds));
+    }
+
+    /**
+     * @param  string|int $id
+     *
+     * @return null|\MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    public function find($id): ?PdkOrder
+    {
+        try {
+            return $this->get($id);
+        } catch (InvalidArgumentException $e) {
+            // Specifically check for the "order not found exception" and return null in that case, rethrow otherwise
+            if ($e->getMessage() === 'Order not found') {
+                return null;
+            }
+            // Fallthrough, re-throw exception if it's not the "order not found" case
+            throw $e;
+        }
+    }
+
+    /**
+     * Fetch a single order by id or throw when it does not exist (implements the contract's
+     * findOrFail()). Intended for callers that treat a missing order as an error rather than a null
+     * result; delegates to find() and raises ModelNotFoundException when nothing is found.
+     *
+     * @param  string|int $id
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     * @throws \MyParcelNL\Pdk\Base\Exception\ModelNotFoundException
+     */
+    public function findOrFail($id): PdkOrder
+    {
+        $order = $this->find($id);
+
+        if (! $order) {
+            throw new ModelNotFoundException(PdkOrder::class, [$id]);
+        }
+
+        return $order;
+    }
+
+    /**
+     * Batch-fetch existing PdkOrders by their PrestaShop order ids.
+     *
+     * Missing ids are skipped (null-safe, like find()).
+     *
+     * Fully bulk: the order base rows are fetched in a single query via PrestaShopCollection, and
+     * the stored MyParcel data and shipments are eager-loaded once for the whole set by
+     * assembleOrders() — no per-order querying. The orders are list-level (the base covers the
+     * order-table fields a grid item needs); use get() when a single, fully-detailed order with
+     * addresses and lines is required.
+     *
+     * @param  int[] $ids
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection
+     */
+    public function findAll(array $ids): PdkOrderCollection
+    {
+        if (empty($ids)) {
+            return new PdkOrderCollection([]);
+        }
+
+        return $this->assembleOrders($this->fetchBasesByOrderIds($ids));
+    }
+
+    /**
+     * Fetch every order in the shop as PdkOrders.
+     *
+     * Mirrors findAll() without an id filter: a single PrestaShopCollection query for the bases,
+     * then one eager-load of stored data and shipments via assembleOrders(). This is unbounded by
+     * the nature of the contract — prefer findAll() with a known id set wherever possible.
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection
+     */
+    public function all(): PdkOrderCollection
+    {
+        return $this->assembleOrders($this->fetchBasesByOrderIds());
+    }
+
+    /**
+     * Build a batch of lightweight PdkOrders directly from a PrestaShop order-grid record set.
+     *
+     * Intended for rendering the order grid: the grid records already carry the base PrestaShop
+     * fields, so no order models are loaded. Bases are taken straight from the records and handed
+     * to assembleOrders(), which eager-loads the MyParcel data and shipments for the whole page in
+     * one query each. Notes are forced empty because the grid does not render them, which avoids a
+     * lazy per-order notes lookup.
+     *
+     * @param  \PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection $collection
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection
+     */
+    public function fromOrderGridCollection(RecordCollection $collection): PdkOrderCollection
+    {
+        $basesByOrderId = [];
+
+        foreach ($collection->all() as $record) {
+            $basesByOrderId[(int) $record['id_order']] = $this->baseFromOrderGridRecord($record);
+        }
+
+        return $this->assembleOrders($basesByOrderId, ['notes' => []]);
     }
 
     /**
@@ -148,20 +263,6 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
         } catch (InvalidArgumentException $e) {
             return null;
         }
-    }
-
-    /**
-     * @param  string|int $id
-     *
-     * @return null|\MyParcelNL\Pdk\App\Order\Model\PdkOrder
-     */
-    public function find($id): ?PdkOrder
-    {
-        if (! $this->psOrderService->exists($id)) {
-            return null;
-        }
-
-        return $this->get($id);
     }
 
     /**
@@ -210,6 +311,177 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     }
 
     /**
+     * Merge the data sets that make up a single order into one PdkOrder.
+     *
+     * This is the single source of merge precedence used by every build path (single and batch):
+     * the prestashop order fields are the foundation, the stored MyParcel data overrides them, and the
+     * eager-loaded relations (shipments, and optionally an empty notes collection) override last.
+     *
+     * @param  array $base      Base order attributes from the platform (order model or grid record).
+     * @param  array $stored    Stored MyParcel data (delivery options, physical properties, exported, ...).
+     * @param  array $relations Separately-resolved relations, applied last so they win (e.g. shipments, notes).
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    private function assembleOrder(array $base, array $stored, array $relations = []): PdkOrder
+    {
+        return new PdkOrder(array_replace($base, $stored, $relations));
+    }
+
+    /**
+     * Assemble many PdkOrders from pre-built bases, eager-loading the shared relations once.
+     *
+     * Intended as the common batch path behind findAll() and fromOrderGridCollection(): callers
+     * supply the per-order base attributes keyed by order id, and this fetches the stored MyParcel
+     * data and shipments for the whole set in a single query each, then merges every order through
+     * assembleOrder(). $relationDefaults are applied as the final override for every order (e.g.
+     * ['notes' => []] to suppress lazy notes loading in list views).
+     *
+     * @param  array $basesByOrderId   Base order attributes keyed by PrestaShop order id.
+     * @param  array $relationDefaults Relation overrides applied to every assembled order.
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection
+     */
+    private function assembleOrders(array $basesByOrderId, array $relationDefaults = []): PdkOrderCollection
+    {
+        if (empty($basesByOrderId)) {
+            return new PdkOrderCollection([]);
+        }
+
+        $orderIds   = array_keys($basesByOrderId);
+        // Eager load the related myparcel data in one query each. Order data is keyed by order id
+        // (findAll), shipments belong to an order via a foreign key (where on orderId).
+        $storedData = $this->psOrderDataRepository->findAll($orderIds);
+        $shipments  = $this->psOrderShipmentRepository->where('orderId', $orderIds);
+
+        $orders = [];
+
+        foreach ($basesByOrderId as $orderId => $base) {
+            $storedRecord = $storedData->first(static function (MyparcelnlOrderData $row) use ($orderId): bool {
+                return $row->getOrderId() === (int) $orderId;
+            });
+
+            $orderShipments = $shipments
+                ->filter(static function (MyparcelnlOrderShipment $shipment) use ($orderId): bool {
+                    return $shipment->getOrderId() === (int) $orderId;
+                })
+                ->map(function (MyparcelnlOrderShipment $shipment): array {
+                    return $this->toShipmentArray($shipment);
+                })
+                ->values();
+
+            $orders[] = $this->assembleOrder(
+                $base,
+                $storedRecord ? ($storedRecord->getData() ?? []) : [],
+                array_replace(['shipments' => $orderShipments], $relationDefaults)
+            );
+        }
+
+        return new PdkOrderCollection($orders);
+    }
+
+    /**
+     * Extract the base PdkOrder attributes from a full PrestaShop order model.
+     *
+     * Intended for build paths that have (or load) the complete order model: produces the platform
+     * foundation fields (identifiers, addresses, prices, lines, invoice, payment) WITHOUT the stored
+     * MyParcel data or shipments, which the assembler merges in separately.
+     *
+     * @param  \Order $psOrder
+     *
+     * @return array
+     */
+    private function baseFromOrder(PsOrder $psOrder): array
+    {
+        $orderProducts = new Collection($psOrder->getProducts() ?: []);
+
+        return [
+            'externalIdentifier'  => $psOrder->id,
+            'shippingAddress'     => $this->addressAdapter->fromOrder($psOrder, 'shipping'),
+            'billingAddress'      => $this->addressAdapter->fromOrder($psOrder, 'billing'),
+            'referenceIdentifier' => $psOrder->reference,
+            'shipmentPrice'       => $this->currencyService->convertToCents($psOrder->total_shipping_tax_incl),
+            'shipmentVat'         => $this->currencyService->convertToCents($psOrder->total_shipping_tax_excl),
+            'lines'               => $this->createOrderLines($orderProducts),
+            'invoiceId'           => $psOrder->id,
+            'invoiceDate'         => $psOrder->date_add,
+            'paymentMethod'       => $psOrder->payment,
+        ];
+    }
+
+    /**
+     * Extract the base PdkOrder attributes from a PrestaShop order-grid record.
+     *
+     * Intended for the grid build path: the grid record already carries the minimal PrestaShop
+     * fields needed for a list item, so this avoids loading the full order model. Stored MyParcel
+     * data and shipments are merged in separately by the assembler.
+     *
+     * @param  array $record A single PrestaShop order-grid record.
+     *
+     * @return array
+     */
+    private function baseFromOrderGridRecord(array $record): array
+    {
+        return [
+            'externalIdentifier'  => $record['id_order'],
+            'referenceIdentifier' => $record['reference'],
+            'invoiceId'           => $record['id_order'],
+            'invoiceDate'         => $record['date_add'],
+            'paymentMethod'       => $record['payment'],
+        ];
+    }
+
+    /**
+     * Bulk-fetch order base attributes keyed by order id with a single PrestaShopCollection query.
+     *
+     * Shared by findAll() and all(): pass ids to restrict to those orders (non-existent ids are
+     * naturally excluded by the query), or null to fetch every order. Reads only the order-table
+     * fields needed for a base; stored MyParcel data and shipments are merged in by assembleOrders().
+     *
+     * @param  null|int[] $ids
+     *
+     * @return array Base order attributes keyed by PrestaShop order id.
+     */
+    private function fetchBasesByOrderIds(?array $ids = null): array
+    {
+        $orders = new PrestaShopCollection(PsOrder::class);
+
+        if (null !== $ids) {
+            $orders->where('id_order', 'in', array_map('intval', $ids));
+        }
+
+        $basesByOrderId = [];
+
+        /** @var \Order $psOrder */
+        foreach ($orders->getResults() as $psOrder) {
+            $basesByOrderId[(int) $psOrder->id] = $this->baseFromOrderGridRecord([
+                'id_order'  => $psOrder->id,
+                'reference' => $psOrder->reference,
+                'date_add'  => $psOrder->date_add,
+                'payment'   => $psOrder->payment,
+            ]);
+        }
+
+        return $basesByOrderId;
+    }
+
+    /**
+     * Serialize a stored shipment entity into the array shape the PdkOrder shipments attribute
+     * expects. Centralizes the shipment mapping so the single and batch build paths stay identical.
+     *
+     * @param  \MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment $shipment
+     *
+     * @return array
+     */
+    private function toShipmentArray(MyparcelnlOrderShipment $shipment): array
+    {
+        return array_replace($shipment->getData(), [
+            'id'      => $shipment->getShipmentId(),
+            'orderId' => $shipment->getOrderId(),
+        ]);
+    }
+
+    /**
      * @param  \MyParcelNL\Pdk\Base\Support\Collection $orderProducts
      *
      * @return array|array[]
@@ -241,6 +513,12 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     }
 
     /**
+     * Fetch and serialize the stored shipments for a single PrestaShop order.
+     *
+     * Intended for the single-order build path (get()): queries the shipments belonging to the
+     * order and maps them through toShipmentArray() into the shape the PdkOrder shipments attribute
+     * expects.
+     *
      * @param  \Order $psOrder
      *
      * @return \MyParcelNL\Pdk\Base\Support\Collection
@@ -249,11 +527,8 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository
     {
         return $this->psOrderShipmentRepository
             ->where('orderId', $psOrder->id)
-            ->map(static function (MyparcelnlOrderShipment $shipment) {
-                return array_replace($shipment->getData(), [
-                    'id'      => $shipment->getShipmentId(),
-                    'orderId' => $shipment->getOrderId(),
-                ]);
+            ->map(function (MyparcelnlOrderShipment $shipment): array {
+                return $this->toShipmentArray($shipment);
             })
             ->values();
     }

--- a/src/Repository/AbstractPsObjectRepository.php
+++ b/src/Repository/AbstractPsObjectRepository.php
@@ -74,6 +74,25 @@ abstract class AbstractPsObjectRepository implements PsObjectRepositoryInterface
     }
 
     /**
+     * Fetch records whose identifier column matches one of the given ids, in a single query.
+     *
+     * Follows Laravel's findMany() convention: an empty id set returns an empty collection rather
+     * than every record — call all() for that. The column matched against is getIdentifierColumn().
+     *
+     * @param  int[] $ids
+     *
+     * @return \MyParcelNL\Pdk\Base\Support\Collection<T>
+     */
+    public function findAll(array $ids = []): Collection
+    {
+        if (empty($ids)) {
+            return new Collection([]);
+        }
+
+        return $this->where($this->getIdentifierColumn(), array_map('intval', $ids));
+    }
+
+    /**
      * @param  array $values
      *
      * @return null|T
@@ -196,6 +215,17 @@ abstract class AbstractPsObjectRepository implements PsObjectRepositoryInterface
     public function where(string $key, $value): Collection
     {
         return new Collection($this->getEntityRepository()->findBy([$key => $value]));
+    }
+
+    /**
+     * The entity property findAll() matches ids against. Defaults to 'id' — Eloquent's conventional
+     * primary key — and is overridden per repository when the identifier column differs.
+     *
+     * @return string
+     */
+    protected function getIdentifierColumn(): string
+    {
+        return 'id';
     }
 
     /**

--- a/src/Repository/PsOrderDataRepository.php
+++ b/src/Repository/PsOrderDataRepository.php
@@ -15,6 +15,17 @@ final class PsOrderDataRepository extends AbstractPsObjectRepository
     protected $entity = MyparcelnlOrderData::class;
 
     /**
+     * Order data is keyed by the order id (it is the entity's primary key), so findAll() matches
+     * against orderId rather than the default 'id'.
+     *
+     * @return string
+     */
+    protected function getIdentifierColumn(): string
+    {
+        return 'orderId';
+    }
+
+    /**
      * @param  string $apiIdentifier
      *
      * @return null|\MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData

--- a/src/Repository/PsOrderShipmentRepository.php
+++ b/src/Repository/PsOrderShipmentRepository.php
@@ -12,4 +12,16 @@ use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment;
 final class PsOrderShipmentRepository extends AbstractPsObjectRepository
 {
     protected $entity = MyparcelnlOrderShipment::class;
+
+    /**
+     * A shipment is identified by its shipmentId (the entity's primary key), so the inherited
+     * findAll() matches against that. Note: fetching the shipments that belong to a set of orders is
+     * a foreign-key lookup, not findAll() — use where('orderId', $orderIds) for that.
+     *
+     * @return string
+     */
+    protected function getIdentifierColumn(): string
+    {
+        return 'shipmentId';
+    }
 }

--- a/src/Service/PsObjectModelService.php
+++ b/src/Service/PsObjectModelService.php
@@ -105,9 +105,10 @@ final class PsObjectModelService implements PsObjectModelServiceInterface
         $id = $this->getId($class, $input);
 
         if ($id) {
+            // Instantiating the model with the id will automatically load it from the database
             $model = new $class($id);
-
-            return $this->exists($class, $model) ? $model : null;
+            // Double check this is an existing model and not just a local copy
+            return $this->isModel($class, $model) && $model->id ? $model : null;
         }
 
         return null;

--- a/src/Service/PsSpecificObjectModelService.php
+++ b/src/Service/PsSpecificObjectModelService.php
@@ -11,6 +11,12 @@ use MyParcelNL\PrestaShop\Contract\PsSpecificObjectModelServiceInterface;
 use ObjectModel;
 
 /**
+ * Locks the generic {@see PsObjectModelService} to one model type.
+ *
+ * Each subclass fixes its model by implementing getClass() (e.g. PsOrderService returns
+ * Order::class). From then on you call get($id) instead of get(Order::class, $id) — every
+ * method here just forwards to the generic service with that class filled in for you.
+ *
  * @template T of ObjectModel
  * @extends \MyParcelNL\PrestaShop\Contract\PsSpecificObjectModelServiceInterface<T>
  */

--- a/tests/Mock/MockPsEntityRepository.php
+++ b/tests/Mock/MockPsEntityRepository.php
@@ -62,7 +62,14 @@ class MockPsEntityRepository extends \Doctrine\ORM\EntityRepository
                 static function (object $object) use ($criteria) {
                     foreach ($criteria as $key => $value) {
                         $getter = sprintf('get%s', Str::studly($key));
-                        if ($object->{$getter}() === $value) {
+                        $actual = $object->{$getter}();
+
+                        // Mirror Doctrine: an array criterion matches any of its values (WHERE IN).
+                        $matches = is_array($value)
+                            ? in_array($actual, $value, true)
+                            : $actual === $value;
+
+                        if ($matches) {
                             continue;
                         }
 

--- a/tests/Mock/MockPsPrestaShopCollection.php
+++ b/tests/Mock/MockPsPrestaShopCollection.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Tests\Mock;
+
+use ObjectModel;
+
+/**
+ * Minimal stand-in for PrestaShop's PrestaShopCollection. Supports only the subset the plugin uses:
+ * an optional primary-id "in" filter plus getResults(). Backed by the same in-memory model registry
+ * as new Order($id), so collection results stay consistent with single-model lookups in tests.
+ */
+abstract class MockPsPrestaShopCollection
+{
+    /**
+     * @var class-string<ObjectModel>
+     */
+    private $className;
+
+    /**
+     * @var null|int[]
+     */
+    private $ids;
+
+    /**
+     * @param  class-string<ObjectModel> $className
+     * @param  null|int                  $idLang
+     */
+    public function __construct(string $className, ?int $idLang = null)
+    {
+        $this->className = $className;
+        $this->ids       = null;
+    }
+
+    /**
+     * Record a filter. Only the primary-id "in" filter the repository relies on is supported; the
+     * field and operator are accepted for signature compatibility but not otherwise interpreted.
+     *
+     * @param  string $field
+     * @param  string $operator
+     * @param  mixed  $value
+     *
+     * @return $this
+     */
+    public function where(string $field, string $operator, $value): self
+    {
+        $this->ids = array_map('intval', (array) $value);
+
+        return $this;
+    }
+
+    /**
+     * Return the matching models. With an id filter, hydrates each existing id through the same path
+     * as new Order($id) and drops ids that do not exist; without a filter, returns every stored model.
+     *
+     * @return \ObjectModel[]
+     */
+    public function getResults(): array
+    {
+        if (null === $this->ids) {
+            return MockPsObjectModels::getByClass($this->className)
+                ->values()
+                ->all();
+        }
+
+        $results = [];
+
+        foreach ($this->ids as $id) {
+            $model = new $this->className($id);
+
+            if ($model->id) {
+                $results[] = $model;
+            }
+        }
+
+        return $results;
+    }
+}

--- a/tests/Mock/ThrowingPsOrderService.php
+++ b/tests/Mock/ThrowingPsOrderService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Tests\Mock;
+
+use InvalidArgumentException;
+use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
+use ObjectModel;
+use Order;
+
+/**
+ * Test double whose get() throws an unexpected (non-"Order not found") InvalidArgumentException.
+ * Used to verify that PsPdkOrderRepository::find() re-throws exceptions it does not recognise rather
+ * than swallowing them. Every other method is a no-op stub since the find()/get() path never reaches
+ * them once get() throws.
+ */
+final class ThrowingPsOrderService implements PsOrderServiceInterface
+{
+    public const MESSAGE = 'unexpected order service failure';
+
+    public function get($input): ?ObjectModel
+    {
+        throw new InvalidArgumentException(self::MESSAGE);
+    }
+
+    public function add(ObjectModel $model): bool
+    {
+        return false;
+    }
+
+    public function create(?int $id = null): ObjectModel
+    {
+        return new Order();
+    }
+
+    public function delete($input, bool $soft = false): bool
+    {
+        return false;
+    }
+
+    public function deleteMany($input, bool $soft = false): bool
+    {
+        return false;
+    }
+
+    public function exists($input): bool
+    {
+        return false;
+    }
+
+    public function getId($input): ?int
+    {
+        return null;
+    }
+
+    public function update(ObjectModel $model): bool
+    {
+        return false;
+    }
+
+    public function getOrderData($input): array
+    {
+        return [];
+    }
+
+    public function getOrderNotes($input): array
+    {
+        return [];
+    }
+
+    public function updateOrderData($input, array $orderData): void
+    {
+    }
+
+    public function updateOrderNotes($input, array $notes): void
+    {
+    }
+}

--- a/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 
 namespace MyParcelNL\PrestaShop\Pdk\Order\Repository;
 
+use MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
 use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Base\Exception\ModelNotFoundException;
 use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
@@ -130,3 +132,106 @@ it('returns null from find() when order does not exist', function () {
 
     expect($result)->toBeNull();
 });
+
+it('finds multiple pdk orders by their ids', function () {
+    /** @var Order $orderA */
+    $orderA = psFactory(Order::class)->store();
+    /** @var Order $orderB */
+    $orderB = psFactory(Order::class)->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->findAll([(int) $orderA->id, (int) $orderB->id]);
+
+    expect($result)
+        ->toBeInstanceOf(PdkOrderCollection::class)
+        ->and($result->count())
+        ->toBe(2)
+        ->and($result->map(static fn (PdkOrder $order): int => (int) $order->externalIdentifier)->all())
+        ->toEqualCanonicalizing([(int) $orderA->id, (int) $orderB->id]);
+});
+
+it('skips ids that do not exist when finding many', function () {
+    /** @var Order $order */
+    $order = psFactory(Order::class)->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->findAll([(int) $order->id, 99999]);
+
+    expect($result->count())
+        ->toBe(1)
+        ->and((int) $result->first()->externalIdentifier)
+        ->toBe((int) $order->id);
+});
+
+it('merges stored order data into orders fetched with findAll', function () {
+    /** @var Order $order */
+    $order = psFactory(Order::class)->store();
+
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId((int) $order->id)
+            ->withData(json_encode(['exported' => true])),
+    ]))->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->findAll([(int) $order->id]);
+
+    expect($result->first()->exported)->toBeTrue();
+});
+
+it('returns an empty collection when finding many with no ids', function () {
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->findAll([]);
+
+    expect($result)
+        ->toBeInstanceOf(PdkOrderCollection::class)
+        ->and($result->count())
+        ->toBe(0);
+});
+
+it('returns every order with all()', function () {
+    /** @var Order $orderA */
+    $orderA = psFactory(Order::class)->store();
+    /** @var Order $orderB */
+    $orderB = psFactory(Order::class)->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->all();
+
+    expect($result)
+        ->toBeInstanceOf(PdkOrderCollection::class)
+        ->and($result->map(static fn (PdkOrder $order): int => (int) $order->externalIdentifier)->all())
+        ->toEqualCanonicalizing([(int) $orderA->id, (int) $orderB->id]);
+});
+
+it('returns an order from findOrFail when it exists', function () {
+    /** @var Order $order */
+    $order = psFactory(Order::class)->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->findOrFail((int) $order->id);
+
+    expect($result)
+        ->toBeInstanceOf(PdkOrder::class)
+        ->and((int) $result->externalIdentifier)
+        ->toBe((int) $order->id);
+});
+
+it('throws from findOrFail when the order does not exist', function () {
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $orderRepository->findOrFail(99999);
+})->throws(ModelNotFoundException::class);

--- a/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
@@ -5,19 +5,30 @@ declare(strict_types=1);
 
 namespace MyParcelNL\PrestaShop\Pdk\Order\Repository;
 
+use InvalidArgumentException;
 use MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
+use MyParcelNL\Pdk\App\Order\Contract\PdkProductRepositoryInterface;
 use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Base\Contract\CurrencyServiceInterface;
 use MyParcelNL\Pdk\Base\Exception\ModelNotFoundException;
+use MyParcelNL\Pdk\Storage\MemoryCacheStorage;
+use MyParcelNL\PrestaShop\Pdk\Base\Adapter\PsAddressAdapter;
+use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
+use MyParcelNL\PrestaShop\Repository\PsOrderShipmentRepository;
+use MyParcelNL\PrestaShop\Service\PsProductService;
+use MyParcelNL\PrestaShop\Tests\Mock\ThrowingPsOrderService;
 use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Tests\Factory\Collection\FactoryCollection;
 use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
+use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment;
 use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
 use Order;
 use OrderFactory;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
 use function MyParcelNL\PrestaShop\psFactory;
@@ -235,3 +246,111 @@ it('throws from findOrFail when the order does not exist', function () {
 
     $orderRepository->findOrFail(99999);
 })->throws(ModelNotFoundException::class);
+
+it('getMany delegates to findAll', function () {
+    /** @var Order $orderA */
+    $orderA = psFactory(Order::class)->store();
+    /** @var Order $orderB */
+    $orderB = psFactory(Order::class)->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->getMany([(int) $orderA->id, (int) $orderB->id]);
+
+    expect($result)
+        ->toBeInstanceOf(PdkOrderCollection::class)
+        ->and($result->count())
+        ->toBe(2);
+});
+
+it('builds pdk orders from an order-grid record collection', function () {
+    /** @var Order $order */
+    $order = psFactory(Order::class)->store();
+
+    /** @var \MyParcelNL\PrestaShop\Pdk\Order\Repository\PsPdkOrderRepository $orderRepository */
+    $orderRepository = Pdk::get(PsPdkOrderRepository::class);
+
+    $collection = new RecordCollection([
+        [
+            'id_order'  => (int) $order->id,
+            'reference' => 'REF-GRID',
+            'date_add'  => '2020-01-01 10:00:00',
+            'payment'   => 'Cash on delivery',
+        ],
+    ]);
+
+    $result = $orderRepository->fromOrderGridCollection($collection);
+
+    expect($result)
+        ->toBeInstanceOf(PdkOrderCollection::class)
+        ->and($result->count())
+        ->toBe(1)
+        ->and((int) $result->first()->externalIdentifier)
+        ->toBe((int) $order->id)
+        ->and($result->first()->referenceIdentifier)
+        ->toBe('REF-GRID');
+});
+
+it('returns an empty collection from all() when there are no orders', function () {
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    expect($orderRepository->all()->count())->toBe(0);
+});
+
+it('eager-loads shipments onto orders fetched with findAll', function () {
+    /** @var Order $order */
+    $order = psFactory(Order::class)->store();
+
+    (new FactoryCollection([
+        factory(MyparcelnlOrderShipment::class)
+            ->withOrderId((int) $order->id)
+            ->withShipmentId(987)
+            ->withData(json_encode(['id' => 987])),
+    ]))->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->findAll([(int) $order->id]);
+
+    expect($result->first()->shipments->count())->toBe(1);
+});
+
+it('loads shipments when fetching a single order with get()', function () {
+    /** @var Order $order */
+    $order = psFactory(Order::class)->store();
+
+    (new FactoryCollection([
+        factory(MyparcelnlOrderShipment::class)
+            ->withOrderId((int) $order->id)
+            ->withShipmentId(654)
+            ->withData(json_encode(['id' => 654])),
+    ]))->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $result = $orderRepository->get((int) $order->id);
+
+    expect($result->shipments->count())->toBe(1);
+});
+
+it('re-throws unexpected exceptions from find() instead of returning null', function () {
+    // get() only throws "Order not found"; inject a service that throws something else to prove
+    // find() does not swallow unrecognised exceptions (the fallthrough re-throw).
+    $orderRepository = new PsPdkOrderRepository(
+        Pdk::get(MemoryCacheStorage::class),
+        Pdk::get(PsOrderShipmentRepository::class),
+        Pdk::get(PsOrderDataRepository::class),
+        Pdk::get(CurrencyServiceInterface::class),
+        Pdk::get(PdkProductRepositoryInterface::class),
+        Pdk::get(PsAddressAdapter::class),
+        new ThrowingPsOrderService(),
+        Pdk::get(PsProductService::class)
+    );
+
+    expect(fn () => $orderRepository->find(1))
+        ->toThrow(InvalidArgumentException::class, ThrowingPsOrderService::MESSAGE);
+});

--- a/tests/Unit/Repository/PsObjectRepositoryFindAllTest.php
+++ b/tests/Unit/Repository/PsObjectRepositoryFindAllTest.php
@@ -1,0 +1,42 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Repository;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Tests\Factory\Collection\FactoryCollection;
+use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
+use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPsPdkInstance());
+
+beforeEach(function () {
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)->withOrderId(1)->withData(json_encode([])),
+        factory(MyparcelnlOrderData::class)->withOrderId(2)->withData(json_encode([])),
+    ]))->store();
+});
+
+it('returns an empty collection from findAll when given no ids', function () {
+    /** @var \MyParcelNL\PrestaShop\Repository\PsOrderDataRepository $repository */
+    $repository = Pdk::get(PsOrderDataRepository::class);
+
+    // Laravel's findMany() convention: no ids means an empty result, never "all".
+    expect($repository->findAll([])->count())->toBe(0);
+});
+
+it('returns only the requested records from findAll', function () {
+    /** @var \MyParcelNL\PrestaShop\Repository\PsOrderDataRepository $repository */
+    $repository = Pdk::get(PsOrderDataRepository::class);
+
+    $result = $repository->findAll([1]);
+
+    expect($result->count())
+        ->toBe(1)
+        ->and($result->first()->getOrderId())
+        ->toBe(1);
+});

--- a/tests/Unit/Repository/PsObjectRepositoryFindAllTest.php
+++ b/tests/Unit/Repository/PsObjectRepositoryFindAllTest.php
@@ -8,6 +8,7 @@ namespace MyParcelNL\PrestaShop\Repository;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Tests\Factory\Collection\FactoryCollection;
 use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
+use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment;
 use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
@@ -39,4 +40,32 @@ it('returns only the requested records from findAll', function () {
         ->toBe(1)
         ->and($result->first()->getOrderId())
         ->toBe(1);
+});
+
+it('matches a repository-specific identifier column in findAll', function () {
+    (new FactoryCollection([
+        factory(MyparcelnlOrderShipment::class)
+            ->withOrderId(1)
+            ->withShipmentId(555)
+            ->withData(json_encode([])),
+    ]))->store();
+
+    /** @var \MyParcelNL\PrestaShop\Repository\PsOrderShipmentRepository $repository */
+    $repository = Pdk::get(PsOrderShipmentRepository::class);
+
+    // The shipment repo overrides getIdentifierColumn() to its primary key (shipmentId).
+    $result = $repository->findAll([555]);
+
+    expect($result->count())
+        ->toBe(1)
+        ->and($result->first()->getShipmentId())
+        ->toBe(555);
+});
+
+it('falls back to the default identifier column for repositories that do not override it', function () {
+    /** @var \MyParcelNL\PrestaShop\Repository\PsCartDeliveryOptionsRepository $repository */
+    $repository = Pdk::get(PsCartDeliveryOptionsRepository::class);
+
+    // No override, so getIdentifierColumn() returns the default 'id'; nothing stored means empty.
+    expect($repository->findAll([999])->count())->toBe(0);
 });

--- a/tests/mock_class_map.php
+++ b/tests/mock_class_map.php
@@ -18,6 +18,7 @@ use MyParcelNL\PrestaShop\Tests\Mock\MockPsLink;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsModule;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsObjectModel;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsOrder;
+use MyParcelNL\PrestaShop\Tests\Mock\MockPsPrestaShopCollection;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsRangeObjectModel;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsSmarty;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsTools;
@@ -53,6 +54,11 @@ final class Db extends DbCore { }
 abstract class DbQueryCore extends MockPsDbQuery { }
 
 final class DbQuery extends DbQueryCore { }
+
+/** @see \PrestaShopCollectionCore */
+abstract class PrestaShopCollectionCore extends MockPsPrestaShopCollection { }
+
+final class PrestaShopCollection extends PrestaShopCollectionCore { }
 
 /** @see \ToolsCore */
 abstract class ToolsCore extends MockPsTools { }

--- a/tests/mock_namespaced_class_map_after.php
+++ b/tests/mock_namespaced_class_map_after.php
@@ -61,3 +61,33 @@ namespace Symfony\Component\Cache\Adapter;
 use MyParcelNL\PrestaShop\Tests\Mock\BaseMock;
 
 class ArrayAdapter extends BaseMock { }
+
+namespace PrestaShop\PrestaShop\Core\Grid\Record;
+
+/**
+ * Minimal stand-in for PrestaShop's grid RecordCollection: holds raw record arrays and exposes
+ * them via all(), which is the only part the module's order-grid hook consumes.
+ */
+class RecordCollection
+{
+    /**
+     * @var array
+     */
+    private $items;
+
+    /**
+     * @param  array $records
+     */
+    public function __construct(array $records = [])
+    {
+        $this->items = $records;
+    }
+
+    /**
+     * @return array
+     */
+    public function all(): array
+    {
+        return $this->items;
+    }
+}


### PR DESCRIPTION
Significantly improve the order grid performance by eager-loading data for all the orders once, rather than for each individually. This should greatly improve the speed of the order grid, especially if you display lots of orders and/or have multiple shipments per order.

Resolves INT-1607