### PR TITLE
chore: restore guzzle scoping removed in capabilities merge

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -39,7 +39,6 @@ return [
         'Symfony\\Component',
         'Symfony\\Contracts',
         'Symfony\\Polyfill',
-        'GuzzleHttp',
         'Psr\\Http\\Message',
         'Psr\\Log',
     ],


### PR DESCRIPTION
Restores the GuzzleHttp scoping that #483 introduced and the capabilities merge (#519) accidentally reverted. The capabilities branch was cut before #483 landed, so its older `scoper.inc.php` exclude list (still containing `GuzzleHttp`) won the merge.

Fixes issues in Prestashop 1.7 due to incompatible Guzzle versions between Prestashop and PDK, by making the PDK always use *its* Guzzle dependency scoped to the PDK rather than a copy from Prestashop itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)