### PR TITLE
feat: add support for custom themes delivery options checkout form

### DIFF
--- a/views/js/frontend/checkout/src/deliveryOptions/utils/showDeliveryOptionsForm.ts
+++ b/views/js/frontend/checkout/src/deliveryOptions/utils/showDeliveryOptionsForm.ts
@@ -7,5 +7,9 @@ export const showDeliveryOptionsForm = (): void => {
     return;
   }
 
+  // Some themes nest .carrier-extra-content inside .delivery-option, which breaks
+  // the theme's own updatedDeliveryForm handler that is supposed to reveal it after a carrier switch.
+  $wrapper.parents('.carrier-extra-content:hidden').show();
+
   $wrapper.stop().show();
 };


### PR DESCRIPTION
**Short summary**
Small defensive addition in de showDeliveryOptionsForm util. Some (custom) themes nest the `.carrier-extra-content` div inside `.delivery-option`. The theme's default updatedDeliveryForm handler uses .next('.carrier-extra-content') to reveal the extra content after a carrier switch, which matches nothing in that structure... so the delivery options stayed hidden until a page refresh.

Tested it locally and on the customer's live site, works as expected & no regression. 


INT-1651