### PR TITLE
chore: carry the carrier data migration as 5.3.0 and make it resumable

### DIFF
--- a/src/Migration/Migration5_3_0.php
+++ b/src/Migration/Migration5_3_0.php
@@ -19,7 +19,7 @@ use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
 use MyParcelNL\PrestaShop\Repository\PsOrderShipmentRepository;
 use Throwable;
 
-final class Migration5_1_0 extends AbstractPsPdkMigration
+final class Migration5_3_0 extends AbstractPsPdkMigration
 {
     /**
      * @var \MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface
@@ -77,7 +77,7 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
 
     public function getVersion(): string
     {
-        return '5.1.0';
+        return '5.3.0';
     }
 
     public function up(): void
@@ -88,6 +88,7 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
         $this->migrateCartDeliveryOptions();
         $this->migrateOrderData();
         $this->migrateShipmentData();
+        $this->clearCursors();
     }
 
     /**
@@ -143,11 +144,21 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
 
     /**
      * Update myparcel_carrier column values in the carrier mapping table from legacy to V2 names.
+     *
+     * The myparcel_carrier column is UNIQUE. A shop that carried both the old (legacy-named) and new
+     * (V2-named) PrestaShop carriers across the transition has both rows present, so renaming a legacy
+     * row to a V2 name that another row already holds would violate the constraint and abort the whole
+     * migration. Such a legacy row is left untouched (and logged) rather than remapped.
      */
     private function migrateCarrierMappings(): void
     {
         $legacyToNewMap = array_flip(Carrier::CARRIER_NAME_TO_LEGACY_MAP);
         $mappings       = $this->carrierMappingRepository->all();
+
+        $usedNames = [];
+        foreach ($mappings as $mapping) {
+            $usedNames[$mapping->getMyparcelCarrier()] = true;
+        }
 
         foreach ($mappings as $mapping) {
             $currentName = $mapping->getMyparcelCarrier();
@@ -157,7 +168,17 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
                 continue;
             }
 
+            if (isset($usedNames[$newName])) {
+                Logger::warning('Skipping carrier mapping migration; target name already in use', [
+                    'from' => $currentName,
+                    'to'   => $newName,
+                ]);
+                continue;
+            }
+
             $mapping->setMyparcelCarrier($newName);
+            unset($usedNames[$currentName]);
+            $usedNames[$newName] = true;
         }
 
         EntityManager::flush();
@@ -170,7 +191,7 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
     {
         $legacyToNewMap = array_flip(Carrier::CARRIER_NAME_TO_LEGACY_MAP);
 
-        $this->migrateInBatches($this->cartDeliveryOptionsRepository, function ($cartOption) use ($legacyToNewMap) {
+        $this->migrateInBatches($this->cartDeliveryOptionsRepository, 'cartId', 'cart_delivery_options', function ($cartOption) use ($legacyToNewMap) {
             $data   = $cartOption->getData();
             $parsed = $this->parseLegacyCarrier($data['carrier'] ?? null);
 
@@ -197,7 +218,7 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
     {
         $legacyToNewMap = array_flip(Carrier::CARRIER_NAME_TO_LEGACY_MAP);
 
-        $this->migrateInBatches($this->orderDataRepository, function ($orderData) use ($legacyToNewMap) {
+        $this->migrateInBatches($this->orderDataRepository, 'orderId', 'order_data', function ($orderData) use ($legacyToNewMap) {
             $data   = $orderData->getData();
             $parsed = $this->parseLegacyCarrier($data['deliveryOptions']['carrier'] ?? null);
 
@@ -225,7 +246,7 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
     {
         $legacyToNewMap = array_flip(Carrier::CARRIER_NAME_TO_LEGACY_MAP);
 
-        $this->migrateInBatches($this->orderShipmentRepository, function ($shipment) use ($legacyToNewMap) {
+        $this->migrateInBatches($this->orderShipmentRepository, 'shipmentId', 'order_shipment', function ($shipment) use ($legacyToNewMap) {
             $data    = $shipment->getData();
             $changed = false;
 
@@ -269,20 +290,38 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
     /**
      * Process entities from a repository in batches to limit memory usage.
      *
+     * Uses keyset pagination on the entity identifier (WHERE id > :cursor ORDER BY id) rather than
+     * OFFSET, both to avoid the deep-offset scan cost on large tables and to give a stable cursor to
+     * persist. Progress is stored after each flushed batch so that a run interrupted by a timeout on a
+     * very large shop resumes where it left off on the next upgrade attempt instead of restarting. The
+     * cursor is only ever written after the batch is committed, so it can never point past uncommitted
+     * data; combined with the idempotent transforms, re-processing an already-migrated row is harmless.
+     *
      * @param  \MyParcelNL\PrestaShop\Repository\AbstractPsObjectRepository $repository
-     * @param  callable                                                      $callback
-     * @param  int                                                           $batchSize
+     * @param  string                                                       $idField    Doctrine identifier field, e.g. "orderId"
+     * @param  string                                                       $cursorName Unique name for the persisted progress cursor
+     * @param  callable                                                     $callback
+     * @param  int                                                          $batchSize
      */
-    private function migrateInBatches(AbstractPsObjectRepository $repository, callable $callback, int $batchSize = 500): void
-    {
+    private function migrateInBatches(
+        AbstractPsObjectRepository $repository,
+        string                     $idField,
+        string                     $cursorName,
+        callable                   $callback,
+        int                        $batchSize = 500
+    ): void {
         /** @var \Doctrine\ORM\EntityManager $em */
-        $em     = Pdk::get('ps.entityManager');
-        $qb     = $em->getRepository($repository->getEntityClass())->createQueryBuilder('e');
-        $offset = 0;
+        $em        = Pdk::get('ps.entityManager');
+        $cursorKey = $this->cursorKey($cursorName);
+        $idGetter  = 'get' . ucfirst($idField);
+        $cursor    = (int) $this->settingsRepository->get($cursorKey);
 
         do {
-            $batch = $qb
-                ->setFirstResult($offset)
+            $batch = $em->getRepository($repository->getEntityClass())
+                ->createQueryBuilder('e')
+                ->where(sprintf('e.%s > :cursor', $idField))
+                ->setParameter('cursor', $cursor)
+                ->orderBy(sprintf('e.%s', $idField), 'ASC')
                 ->setMaxResults($batchSize)
                 ->getQuery()
                 ->getResult();
@@ -296,13 +335,36 @@ final class Migration5_1_0 extends AbstractPsPdkMigration
                         'error'  => $e->getMessage(),
                     ]);
                 }
+
+                // Advance past this row regardless of callback outcome, so a poison row is not retried forever.
+                $cursor = $entity->{$idGetter}();
             }
 
             EntityManager::flush();
             $em->clear();
 
-            $offset += $batchSize;
+            // Persist progress only after the batch is committed; re-runs resume from here.
+            $this->settingsRepository->store($cursorKey, $cursor);
         } while (count($batch) === $batchSize);
+    }
+
+    /**
+     * Build the settings key used to persist a per-table batch-migration progress cursor.
+     */
+    private function cursorKey(string $cursorName): string
+    {
+        return Pdk::get('createSettingsKey')('migration_5_3_0_cursor_' . $cursorName);
+    }
+
+    /**
+     * Remove the persisted progress cursors once the migration has run to completion, so a future
+     * migration does not skip rows based on a stale cursor.
+     */
+    private function clearCursors(): void
+    {
+        foreach (['cart_delivery_options', 'order_data', 'order_shipment'] as $cursorName) {
+            $this->settingsRepository->store($this->cursorKey($cursorName), null);
+        }
     }
 
     /**

--- a/src/Pdk/Installer/Service/PsMigrationService.php
+++ b/src/Pdk/Installer/Service/PsMigrationService.php
@@ -7,7 +7,7 @@ namespace MyParcelNL\PrestaShop\Pdk\Installer\Service;
 use MyParcelNL\Pdk\App\Installer\Contract\MigrationServiceInterface;
 use MyParcelNL\PrestaShop\Migration\Migration4_0_0;
 use MyParcelNL\PrestaShop\Migration\Migration4_2_3;
-use MyParcelNL\PrestaShop\Migration\Migration5_1_0;
+use MyParcelNL\PrestaShop\Migration\Migration5_3_0;
 
 final class PsMigrationService implements MigrationServiceInterface
 {
@@ -19,7 +19,7 @@ final class PsMigrationService implements MigrationServiceInterface
         return [
             Migration4_0_0::class,
             Migration4_2_3::class,
-            Migration5_1_0::class,
+            Migration5_3_0::class,
         ];
     }
 }

--- a/tests/Mock/MockPsEntityRepository.php
+++ b/tests/Mock/MockPsEntityRepository.php
@@ -100,8 +100,9 @@ class MockPsEntityRepository extends \Doctrine\ORM\EntityRepository
 
     /**
      * Return a minimal fluent QueryBuilder mock backed by findAll(). The migration code
-     * uses setFirstResult/setMaxResults/getQuery()->getResult() for batched iteration —
-     * the mock honours both offsets so multi-batch test scenarios converge.
+     * uses where()/setParameter()/orderBy()/setMaxResults()/getQuery()->getResult() for
+     * keyset-paginated batched iteration — the mock mirrors that so multi-batch and
+     * resume-from-cursor test scenarios converge.
      *
      * @param  string $alias unused; matches the Doctrine signature
      */

--- a/tests/Mock/MockPsQueryBuilder.php
+++ b/tests/Mock/MockPsQueryBuilder.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace MyParcelNL\PrestaShop\Tests\Mock;
 
+use MyParcelNL\Sdk\Support\Str;
+
 /**
- * Minimal Doctrine QueryBuilder/Query mock used by migration tests to iterate a
- * collection in batches via setFirstResult/setMaxResults/getQuery()->getResult().
+ * Minimal Doctrine QueryBuilder/Query mock used by migration tests. Mirrors the keyset pagination the
+ * migration performs: where('e.<field> > :cursor') + setParameter('cursor', N) + orderBy('e.<field>')
+ * + setMaxResults(), iterated via getQuery()->getResult().
  */
 final class MockPsQueryBuilder
 {
@@ -16,9 +19,19 @@ final class MockPsQueryBuilder
     private $entities;
 
     /**
+     * @var null|string
+     */
+    private $cursorField;
+
+    /**
      * @var int
      */
-    private $firstResult = 0;
+    private $cursorValue = 0;
+
+    /**
+     * @var null|string
+     */
+    private $orderField;
 
     /**
      * @var null|int
@@ -33,9 +46,36 @@ final class MockPsQueryBuilder
         $this->entities = array_values($entities);
     }
 
-    public function setFirstResult(int $firstResult): self
+    /**
+     * Parses the keyset predicate "e.<field> > :cursor" to learn which identifier to page on.
+     */
+    public function where(string $predicate): self
     {
-        $this->firstResult = $firstResult;
+        if (preg_match('/e\.(\w+)\s*>/', $predicate, $matches)) {
+            $this->cursorField = $matches[1];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  string $name
+     * @param  mixed  $value
+     */
+    public function setParameter(string $name, $value): self
+    {
+        if ('cursor' === $name) {
+            $this->cursorValue = (int) $value;
+        }
+
+        return $this;
+    }
+
+    public function orderBy(string $field, string $direction = 'ASC'): self
+    {
+        if (preg_match('/e\.(\w+)/', $field, $matches)) {
+            $this->orderField = $matches[1];
+        }
 
         return $this;
     }
@@ -57,6 +97,27 @@ final class MockPsQueryBuilder
      */
     public function getResult(): array
     {
-        return array_slice($this->entities, $this->firstResult, $this->maxResults);
+        $rows = $this->entities;
+
+        if (null !== $this->cursorField) {
+            $getter = $this->getterFor($this->cursorField);
+            $rows   = array_values(array_filter($rows, function (object $entity) use ($getter): bool {
+                return $entity->{$getter}() > $this->cursorValue;
+            }));
+        }
+
+        if (null !== $this->orderField) {
+            $getter = $this->getterFor($this->orderField);
+            usort($rows, static function (object $a, object $b) use ($getter): int {
+                return $a->{$getter}() <=> $b->{$getter}();
+            });
+        }
+
+        return array_slice($rows, 0, $this->maxResults);
+    }
+
+    private function getterFor(string $field): string
+    {
+        return sprintf('get%s', Str::studly($field));
     }
 }

--- a/tests/Unit/Hooks/HasPsCarrierListHooksTest.php
+++ b/tests/Unit/Hooks/HasPsCarrierListHooksTest.php
@@ -88,7 +88,7 @@ function fakeCapabilitiesRepositoryThrowing(): CarrierCapabilitiesRepository
 }
 
 /**
- * Standard fixture: install N carrier mappings (V2 names — Migration5_1_0 has already run by now),
+ * Standard fixture: install N carrier mappings (V2 names — Migration5_3_0 has already run by now),
  * one PS-only carrier (no mapping) that must always survive, and a delivery address in the given country.
  *
  * @return array{0: array, 1: array<string,int>}  [hookParams, v2Name => psCarrierId map]

--- a/tests/Unit/Migration/Migration5_3_0Test.php
+++ b/tests/Unit/Migration/Migration5_3_0Test.php
@@ -34,8 +34,8 @@ it('remaps legacy carrier setting keys to V2 format', function () {
         'dhlparcelconnect' => ['delivery_enabled' => '0'],
     ]);
 
-    /** @var Migration5_1_0 $migration */
-    $migration = Pdk::get(Migration5_1_0::class);
+    /** @var Migration5_3_0 $migration */
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $result = $settingsRepo->get($settingsKey);
@@ -51,8 +51,8 @@ it('remaps legacy carrier setting keys to V2 format', function () {
 });
 
 it('does not fail when carrier settings are empty', function () {
-    /** @var Migration5_1_0 $migration */
-    $migration = Pdk::get(Migration5_1_0::class);
+    /** @var Migration5_3_0 $migration */
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     /** @var \MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface $settingsRepo */
@@ -72,8 +72,8 @@ it('preserves settings that already use V2 key format', function () {
         'BPOST'  => ['delivery_enabled' => '1'],
     ]);
 
-    /** @var Migration5_1_0 $migration */
-    $migration = Pdk::get(Migration5_1_0::class);
+    /** @var Migration5_3_0 $migration */
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $result = $settingsRepo->get($settingsKey);
@@ -96,7 +96,7 @@ it('migrates carrier mapping table entries to V2 names', function () {
             ->withCarrierId(24),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo     = Pdk::get(PsCarrierMappingRepository::class);
@@ -116,11 +116,41 @@ it('skips carrier mappings that are already V2 format', function () {
             ->withCarrierId(21),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsCarrierMappingRepository::class);
     expect($repo->all()->first()->getMyparcelCarrier())->toBe('POSTNL');
+});
+
+it('does not remap a legacy carrier mapping when its V2 target already exists', function () {
+    // A shop that carried both the old (legacy-named) and new (V2-named) PS carriers across
+    // the transition. Renaming the legacy row to V2 would collide with the existing V2 row on
+    // the UNIQUE(myparcel_carrier) key, so the legacy row must be left as-is instead.
+    (new FactoryCollection([
+        factory(MyparcelnlCarrierMapping::class)
+            ->withMyparcelCarrier('dhlforyou')
+            ->withCarrierId(7),
+        factory(MyparcelnlCarrierMapping::class)
+            ->withMyparcelCarrier('DHL_FOR_YOU')
+            ->withCarrierId(13),
+        // A legacy row with no V2 counterpart must still migrate normally.
+        factory(MyparcelnlCarrierMapping::class)
+            ->withMyparcelCarrier('postnl')
+            ->withCarrierId(5),
+    ]))->store();
+
+    Pdk::get(Migration5_3_0::class)->up();
+
+    $repo    = Pdk::get(PsCarrierMappingRepository::class);
+    $byId = [];
+    foreach ($repo->all() as $mapping) {
+        $byId[$mapping->getCarrierId()] = $mapping->getMyparcelCarrier();
+    }
+
+    expect($byId[7])->toBe('dhlforyou')          // skipped — V2 target already taken
+        ->and($byId[13])->toBe('DHL_FOR_YOU')    // pre-existing V2 row untouched
+        ->and($byId[5])->toBe('POSTNL');         // no conflict — migrated as usual
 });
 
 dataset('cart delivery options carrier variants', [
@@ -137,7 +167,7 @@ it('normalises the carrier field in cart delivery options', function (array $car
             ->withData(json_encode($cartData)),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsCartDeliveryOptionsRepository::class);
@@ -153,7 +183,7 @@ it('skips cart delivery options without carrier field', function () {
             ->withData(json_encode(['deliveryType' => 'standard'])),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsCartDeliveryOptionsRepository::class);
@@ -175,7 +205,7 @@ it('normalises the carrier field in order data', function (array $orderData, str
             ->withData(json_encode($orderData)),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo  = Pdk::get(PsOrderDataRepository::class);
@@ -191,7 +221,7 @@ it('skips order data rows without deliveryOptions', function () {
             ->withData(json_encode(['notes' => 'test'])),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsOrderDataRepository::class);
@@ -214,7 +244,7 @@ it('normalises the carrier field in shipment data', function (array $shipmentDat
             ->withData(json_encode($shipmentData)),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsOrderShipmentRepository::class);
@@ -238,7 +268,7 @@ it('migrates multiple order data rows in a single run', function () {
             ->withData(json_encode(['deliveryOptions' => ['carrier' => 'POSTNL']])),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsOrderDataRepository::class);
@@ -264,7 +294,7 @@ it('migrates multiple shipment data rows in a single run', function () {
             ->withData(json_encode(['carrier' => 'dhlparcelconnect'])),
     ]))->store();
 
-    $migration = Pdk::get(Migration5_1_0::class);
+    $migration = Pdk::get(Migration5_3_0::class);
     $migration->up();
 
     $repo = Pdk::get(PsOrderShipmentRepository::class);
@@ -275,8 +305,8 @@ it('migrates multiple shipment data rows in a single run', function () {
 });
 
 it('does not fail when no account is available during migration', function () {
-    /** @var Migration5_1_0 $migration */
-    $migration = Pdk::get(Migration5_1_0::class);
+    /** @var Migration5_3_0 $migration */
+    $migration = Pdk::get(Migration5_3_0::class);
 
     // migrateAccountData is wrapped in try/catch; no account configured means it silently returns
     expect(fn() => $migration->up())->not->toThrow(\Throwable::class);
@@ -284,4 +314,50 @@ it('does not fail when no account is available during migration', function () {
     /** @var \MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface $accountRepo */
     $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
     expect($accountRepo->getAccount())->toBeNull();
+});
+
+it('resumes order data migration from a stored cursor, skipping rows at or below it', function () {
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId(1)
+            ->withData(json_encode(['deliveryOptions' => ['carrier' => 'postnl']])),
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId(2)
+            ->withData(json_encode(['deliveryOptions' => ['carrier' => 'dhlforyou']])),
+    ]))->store();
+
+    /** @var \MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface $settingsRepo */
+    $settingsRepo = Pdk::get(PdkSettingsRepositoryInterface::class);
+
+    // Simulate a prior run that timed out after processing order 1.
+    $settingsRepo->store(Pdk::get('createSettingsKey')('migration_5_3_0_cursor_order_data'), 1);
+
+    Pdk::get(Migration5_3_0::class)->up();
+
+    $repo = Pdk::get(PsOrderDataRepository::class);
+
+    // Order 1 is at/below the cursor → skipped → stays legacy.
+    // Order 2 is above the cursor → migrated to V2.
+    expect($repo->findOneBy(['orderId' => 1])->getData()['deliveryOptions']['carrier'])->toBe('postnl')
+        ->and($repo->findOneBy(['orderId' => 2])->getData()['deliveryOptions']['carrier'])->toBe('DHL_FOR_YOU');
+});
+
+it('clears the migration cursor after a completed run', function () {
+    (new FactoryCollection([
+        factory(MyparcelnlOrderData::class)
+            ->withOrderId(1)
+            ->withData(json_encode(['deliveryOptions' => ['carrier' => 'postnl']])),
+    ]))->store();
+
+    /** @var \MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface $settingsRepo */
+    $settingsRepo = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $cursorKey    = Pdk::get('createSettingsKey')('migration_5_3_0_cursor_order_data');
+
+    // A leftover cursor from an interrupted run must be cleared once the migration completes,
+    // so a future migration does not skip rows.
+    $settingsRepo->store($cursorKey, 99);
+
+    Pdk::get(Migration5_3_0::class)->up();
+
+    expect($settingsRepo->get($cursorKey))->toBeEmpty();
 });


### PR DESCRIPTION
Renames the carrier-data migration from 5.1.0 to 5.3.0 so it runs on the next release, and hardens it so large shops can complete the upgrade reliably:

- The batched order/shipment/cart migration now uses keyset pagination with a per-table progress cursor persisted to configuration after each committed batch. A run interrupted by a PHP timeout on a very large shop resumes where it left off on the next upgrade attempt instead of restarting, and converges across retries. Keyset paging also avoids the deep-OFFSET scan cost.
- Carrier-mapping remapping now skips (and logs) a legacy row whose V2 target name already exists, instead of aborting the whole migration on the UNIQUE(myparcel_carrier) constraint when a shop carried both the legacy and V2 carrier rows across the transition.

Verified end-to-end against real databases on PrestaShop 1.7, 8 and 9 (Doctrine ORM 2.7-2.20, PHP 7.4-8.1), including the scoped build on 1.7.

Resolves INT-1653
