### PR TITLE
fix(order): load full orders for export

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7bd7de3edb6f7ba410dac0eaee00b48e",
+    "content-hash": "8712d9e46da145935b86476c2f41a733",
     "packages": [
         {
             "name": "fruitcake/php-cors",
@@ -471,16 +471,16 @@
         },
         {
             "name": "myparcelnl/pdk",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "f6e820b281bad7ee85829d4b19e1de6bfc4beec9"
+                "reference": "23215d9ca7d840e94f154602fedf47ea966d2bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/f6e820b281bad7ee85829d4b19e1de6bfc4beec9",
-                "reference": "f6e820b281bad7ee85829d4b19e1de6bfc4beec9",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/23215d9ca7d840e94f154602fedf47ea966d2bae",
+                "reference": "23215d9ca7d840e94f154602fedf47ea966d2bae",
                 "shasum": ""
             },
             "require": {
@@ -527,9 +527,9 @@
             "homepage": "https://myparcel.nl",
             "support": {
                 "issues": "https://github.com/myparcelnl/pdk/issues",
-                "source": "https://github.com/myparcelnl/pdk/tree/v4.0.0"
+                "source": "https://github.com/myparcelnl/pdk/tree/v4.0.1"
             },
-            "time": "2026-06-04T10:47:17+00:00"
+            "time": "2026-06-16T17:48:44+00:00"
         },
         {
             "name": "myparcelnl/sdk",

--- a/src/Pdk/Order/Repository/PsPdkOrderRepository.php
+++ b/src/Pdk/Order/Repository/PsPdkOrderRepository.php
@@ -13,7 +13,6 @@ use MyParcelNL\Pdk\App\Order\Repository\AbstractPdkOrderRepository;
 use MyParcelNL\Pdk\Base\Contract\CurrencyServiceInterface;
 use MyParcelNL\Pdk\Base\Exception\ModelNotFoundException;
 use MyParcelNL\Pdk\Base\Support\Collection;
-use MyParcelNL\Pdk\Base\Support\Utils;
 use MyParcelNL\Pdk\Shipment\Model\Shipment;
 use MyParcelNL\Pdk\Storage\MemoryCacheStorage;
 use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
@@ -128,16 +127,17 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository implements P
     }
 
     /**
-     * Get multiple items by their identifier,
-     * proxies to findAll() for backward compatibility until getMany() is removed in favor of findAll()
-     * in the next major version.
+     * Get multiple fully-detailed orders by their identifier.
+     *
+     * Action flows such as export need addresses, lines and prices. Keep findAll() as the
+     * lightweight list-level lookup used by the order grid.
      *
      * @param string|string[] $orderIds
      * @return PdkOrderCollection
      */
     public function getMany($orderIds): PdkOrderCollection
     {
-        return $this->findAll(Utils::toArray($orderIds));
+        return parent::getMany($orderIds);
     }
 
     /**

--- a/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
@@ -26,6 +26,8 @@ use MyParcelNL\Pdk\Tests\Factory\Collection\FactoryCollection;
 use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderData;
 use MyParcelNL\PrestaShop\Entity\MyparcelnlOrderShipment;
 use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
+use Address;
+use Country;
 use Order;
 use OrderFactory;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
@@ -247,21 +249,33 @@ it('throws from findOrFail when the order does not exist', function () {
     $orderRepository->findOrFail(99999);
 })->throws(ModelNotFoundException::class);
 
-it('getMany delegates to findAll', function () {
-    /** @var Order $orderA */
-    $orderA = psFactory(Order::class)->store();
-    /** @var Order $orderB */
-    $orderB = psFactory(Order::class)->store();
+it('loads full order data when fetching many orders', function () {
+    /** @var Country $country */
+    $country = psFactory(Country::class)
+        ->withIsoCode('NL')
+        ->store();
+
+    /** @var Address $deliveryAddress */
+    $deliveryAddress = psFactory(Address::class)
+        ->withCountry($country)
+        ->store();
+
+    /** @var Order $order */
+    $order = psFactory(Order::class)
+        ->withAddressDelivery($deliveryAddress)
+        ->store();
 
     /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
     $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
 
-    $result = $orderRepository->getMany([(int) $orderA->id, (int) $orderB->id]);
+    $result = $orderRepository->getMany([(int) $order->id]);
 
     expect($result)
         ->toBeInstanceOf(PdkOrderCollection::class)
         ->and($result->count())
-        ->toBe(2);
+        ->toBe(1)
+        ->and($result->first()->shippingAddress->cc)
+        ->toBe('NL');
 });
 
 it('builds pdk orders from an order-grid record collection', function () {


### PR DESCRIPTION
Since #543, getMany() proxied to findAll() (for the performance of the order grid), export was missing shippingAddress.cc and the API returned a 422. Delegate getMany() to parent::getMany() so each order loads fully. findAll() stays for the grid.

Also bumps the pdk to 4.0.1.
