### PR TITLE
chore: run PDK console commands from the module locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Running PDK console commands
 
-This module is built on the [MyParcel PDK](https://github.com/myparcelnl/pdk). With the PDK linked locally for development (`pdk-dev-on`), you can run any PDK console command from the module root:
-
+This module is built on the [MyParcel PDK](https://github.com/myparcelnl/pdk). With the PDK linked locally for development (`pdk-dev-on`) **and its dependencies installed** (run `composer install` in the linked PDK repo), you can run any PDK console command from the module root:
 ```sh
 composer console <command>
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ When upgrading to v4.x it may be necessary to first clear the cache of Prestasho
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+## Running PDK console commands
+
+This module is built on the [MyParcel PDK](https://github.com/myparcelnl/pdk). With the PDK linked locally for development (`pdk-dev-on`), you can run any PDK console command from the module root:
+
+```sh
+composer console <command>
+```
+
+Run `composer console list` to see all available commands, or `composer console help <command>` for a command's full usage.
+
 ## Versions
 
 The 1.7 module was initially considered a completely standalone module from the old 1.6 version, and released as version 1.0. This has caused some confusion among users as well as our developers and support team. This will also be able to cause issues in the future when we release new versions that include migrations based on the previously installed version of the module.

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "spatie/pest-plugin-snapshots": "^1.1.0"
   },
   "scripts": {
+    "console": "php vendor/myparcelnl/pdk/bin/console",
     "test": "php -d auto_prepend_file=tests/bootstrap.php vendor/bin/pest",
     "test:snapshots": "php -d auto_prepend_file=tests/bootstrap.php vendor/bin/pest -d --update-snapshots",
     "test:coverage": "php -dpcov.enabled=1 -d auto_prepend_file=tests/bootstrap.php vendor/bin/pest --coverage-clover=clover.xml --coverage-html=coverage"


### PR DESCRIPTION
Adds a `console` composer script so developers can run any MyParcel PDK console command from the module locally — e.g. the timestamped-migration scaffolder (`generate:migration`) and the code generators — when the PDK is dev-linked via `pdk-dev-on`.

Run `composer console list` for available commands and `composer console help <command>` for usage. README has a short pointer.

Independent of any PDK change; works against the dev-linked PDK.

Refs INT-951

🤖 Generated with [Claude Code](https://claude.com/claude-code)