### PR TITLE
fix: make checkout delivery options available on the order immediately

### DIFF
--- a/myparcelnl.php
+++ b/myparcelnl.php
@@ -20,6 +20,7 @@ use MyParcelNL\PrestaShop\Hooks\HasPdkRenderHooks;
 use MyParcelNL\PrestaShop\Hooks\HasPdkScriptHooks;
 use MyParcelNL\PrestaShop\Hooks\HasPsCarrierListHooks;
 use MyParcelNL\PrestaShop\Hooks\HasPsCarrierUpdateHooks;
+use MyParcelNL\PrestaShop\Hooks\HasPsOrderHooks;
 use MyParcelNL\PrestaShop\Hooks\HasPsShippingCostHooks;
 use function MyParcelNL\PrestaShop\bootPdk;
 
@@ -48,6 +49,7 @@ class MyParcelNL extends CarrierModule
     use HasPdkScriptHooks;
     use HasPsCarrierListHooks;
     use HasPsCarrierUpdateHooks;
+    use HasPsOrderHooks;
     use HasPsShippingCostHooks;
 
     private static ?string $versionFromComposer = null;

--- a/src/Hooks/HasPsOrderHooks.php
+++ b/src/Hooks/HasPsOrderHooks.php
@@ -15,17 +15,17 @@ use Throwable;
 trait HasPsOrderHooks
 {
     /**
-     * Eagerly transfers delivery options from the cart to the order when the order is validated.
-     * Prevents the race condition where the lazy fallback in PsOrderService::getFromCart() runs
-     * before cart delivery options are available and persists an empty record.
+     * Eagerly transfers delivery options from the cart to the order when the order is validated,
+     * so the admin order grid shows the correct carrier and options on first render instead of
+     * relying on the lazy fallback in PsOrderService::getFromCart() (which remains as a safety net).
      *
-     * @param  array{order: Order} $params
+     * @param  array{order?: Order} $params
      *
      * @return void
      */
     public function hookActionValidateOrder(array $params): void
     {
-        /** @var Order $order */
+        /** @var Order|null $order */
         $order = $params['order'] ?? null;
 
         if (! $order instanceof Order) {

--- a/src/Hooks/HasPsOrderHooks.php
+++ b/src/Hooks/HasPsOrderHooks.php
@@ -17,7 +17,11 @@ trait HasPsOrderHooks
     /**
      * Eagerly transfers delivery options from the cart to the order when the order is validated,
      * so the admin order grid shows the correct carrier and options on first render instead of
-     * relying on the lazy fallback in PsOrderService::getFromCart() (which remains as a safety net).
+     * relying on the lazy fallback in PsOrderService::getFromCart().
+     *
+     * An order data record is always persisted — empty when the cart has no delivery options — to
+     * mark the order as processed, so PsOrderService::getOrderData() returns the stored value
+     * instead of re-querying the cart on every read.
      *
      * This hook fires exactly once per order, dispatched from PaymentModule::validateOrder() during
      * the checkout payment flow — before the order is ever accessible in the back-office. Admin order
@@ -43,18 +47,14 @@ trait HasPsOrderHooks
 
             $fromCart = $cartDeliveryOptionsRepo->findOneBy(['cartId' => $order->id_cart]);
 
-            if (! $fromCart) {
-                Logger::debug("[Order {$order->id}] No cart delivery options to transfer on validate");
-
-                return;
-            }
+            $orderData = $fromCart ? ['deliveryOptions' => $fromCart->getData()] : [];
 
             /** @var PsOrderDataRepository $orderDataRepo */
             $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
 
             $orderDataRepo->updateOrCreate(
                 ['orderId' => $order->id],
-                ['data'    => json_encode(['deliveryOptions' => $fromCart->getData()])]
+                ['data'    => json_encode($orderData)]
             );
 
             EntityManager::flush();

--- a/src/Hooks/HasPsOrderHooks.php
+++ b/src/Hooks/HasPsOrderHooks.php
@@ -19,6 +19,11 @@ trait HasPsOrderHooks
      * so the admin order grid shows the correct carrier and options on first render instead of
      * relying on the lazy fallback in PsOrderService::getFromCart() (which remains as a safety net).
      *
+     * This hook fires exactly once per order, dispatched from PaymentModule::validateOrder() during
+     * the checkout payment flow — before the order is ever accessible in the back-office. Admin order
+     * modifications go through different hooks (hookActionUpdateOrder etc.), so there is no risk of
+     * overwriting manually changed order data.
+     *
      * @param  array{order?: Order} $params
      *
      * @return void

--- a/src/Hooks/HasPsOrderHooks.php
+++ b/src/Hooks/HasPsOrderHooks.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Hooks;
+
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\PrestaShop\Facade\EntityManager;
+use MyParcelNL\PrestaShop\Repository\PsCartDeliveryOptionsRepository;
+use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
+use Order;
+use Throwable;
+
+trait HasPsOrderHooks
+{
+    /**
+     * Eagerly transfers delivery options from the cart to the order when the order is validated.
+     * Prevents the race condition where the lazy fallback in PsOrderService::getFromCart() runs
+     * before cart delivery options are available and persists an empty record.
+     *
+     * @param  array{order: Order} $params
+     *
+     * @return void
+     */
+    public function hookActionValidateOrder(array $params): void
+    {
+        /** @var Order $order */
+        $order = $params['order'] ?? null;
+
+        if (! $order instanceof Order) {
+            return;
+        }
+
+        try {
+            /** @var PsCartDeliveryOptionsRepository $cartDeliveryOptionsRepo */
+            $cartDeliveryOptionsRepo = Pdk::get(PsCartDeliveryOptionsRepository::class);
+
+            $fromCart = $cartDeliveryOptionsRepo->findOneBy(['cartId' => $order->id_cart]);
+
+            if (! $fromCart) {
+                Logger::debug("[Order {$order->id}] No cart delivery options to transfer on validate");
+
+                return;
+            }
+
+            /** @var PsOrderDataRepository $orderDataRepo */
+            $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
+
+            $orderDataRepo->updateOrCreate(
+                ['orderId' => $order->id],
+                ['data'    => json_encode(['deliveryOptions' => $fromCart->getData()])]
+            );
+
+            EntityManager::flush();
+
+            Logger::debug("[Order {$order->id}] Delivery options transferred from cart on validate");
+        } catch (Throwable $e) {
+            Logger::error('Failed to transfer delivery options on order validate', [
+                'exception' => $e,
+                'orderId'   => $order->id ?? null,
+            ]);
+        }
+    }
+}

--- a/src/Service/PsOrderService.php
+++ b/src/Service/PsOrderService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelNL\PrestaShop\Service;
 
-use InvalidArgumentException;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\PrestaShop\Contract\PsObjectModelServiceInterface;
 use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
@@ -82,7 +81,7 @@ final class PsOrderService extends PsSpecificObjectModelService implements PsOrd
         $fromOrder = $this->psOrderDataRepository->findOneBy(['orderId' => $this->getId($input)]);
 
         if (! $fromOrder) {
-            throw new InvalidArgumentException('Order could not be found');
+            return [];
         }
 
         return $fromOrder->getNotes();
@@ -138,13 +137,15 @@ final class PsOrderService extends PsSpecificObjectModelService implements PsOrd
         $id       = $this->getId($order);
         $fromCart = $this->psCartDeliveryOptionsRepository->findOneBy(['cartId' => $order->id_cart]);
 
-        if ($fromCart) {
-            Logger::debug("[Order $id] Delivery options found in cart, saving to order");
-        } else {
-            Logger::debug("[Order $id] Saving empty order data to order");
+        if (! $fromCart) {
+            Logger::debug("[Order $id] No cart delivery options found, returning empty");
+
+            return [];
         }
 
-        $orderData = $fromCart ? ['deliveryOptions' => $fromCart->getData()] : [];
+        Logger::debug("[Order $id] Delivery options found in cart, saving to order");
+
+        $orderData = ['deliveryOptions' => $fromCart->getData()];
 
         $this->updateOrderData($order, $orderData);
 

--- a/src/Service/PsOrderService.php
+++ b/src/Service/PsOrderService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\PrestaShop\Service;
 
+use InvalidArgumentException;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\PrestaShop\Contract\PsObjectModelServiceInterface;
 use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
@@ -81,7 +82,7 @@ final class PsOrderService extends PsSpecificObjectModelService implements PsOrd
         $fromOrder = $this->psOrderDataRepository->findOneBy(['orderId' => $this->getId($input)]);
 
         if (! $fromOrder) {
-            return [];
+            throw new InvalidArgumentException('Order could not be found');
         }
 
         return $fromOrder->getNotes();
@@ -137,15 +138,13 @@ final class PsOrderService extends PsSpecificObjectModelService implements PsOrd
         $id       = $this->getId($order);
         $fromCart = $this->psCartDeliveryOptionsRepository->findOneBy(['cartId' => $order->id_cart]);
 
-        if (! $fromCart) {
-            Logger::debug("[Order $id] No cart delivery options found, returning empty");
-
-            return [];
+        if ($fromCart) {
+            Logger::debug("[Order $id] Delivery options found in cart, saving to order");
+        } else {
+            Logger::debug("[Order $id] Saving empty order data to order");
         }
 
-        Logger::debug("[Order $id] Delivery options found in cart, saving to order");
-
-        $orderData = ['deliveryOptions' => $fromCart->getData()];
+        $orderData = $fromCart ? ['deliveryOptions' => $fromCart->getData()] : [];
 
         $this->updateOrderData($order, $orderData);
 

--- a/tests/Unit/Hooks/HasPsOrderHooksTest.php
+++ b/tests/Unit/Hooks/HasPsOrderHooksTest.php
@@ -1,0 +1,66 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection,AutoloadingIssuesInspection,PhpIllegalPsrClassPathInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Hooks;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\PrestaShop\Repository\PsCartDeliveryOptionsRepository;
+use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
+use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
+use Order;
+use function MyParcelNL\Pdk\Tests\usesShared;
+use function MyParcelNL\PrestaShop\psFactory;
+
+final class ClassWithPsOrderHooks
+{
+    use HasPsOrderHooks;
+}
+
+usesShared(new UsesMockPsPdkInstance());
+
+it('transfers delivery options from cart to order on validate', function () {
+    $cart  = psFactory(\Cart::class)->store();
+    $order = psFactory(Order::class)->withIdCart($cart->id)->store();
+
+    $rawDeliveryOptions = [
+        DeliveryOptions::CARRIER       => 'postnl',
+        DeliveryOptions::DELIVERY_TYPE => DeliveryOptions::DELIVERY_TYPE_STANDARD_NAME,
+    ];
+
+    /** @var PsCartDeliveryOptionsRepository $cartDeliveryOptionsRepo */
+    $cartDeliveryOptionsRepo = Pdk::get(PsCartDeliveryOptionsRepository::class);
+    $cartDeliveryOptionsRepo->updateOrCreate(
+        ['cartId' => $cart->id],
+        ['data'   => json_encode($rawDeliveryOptions)]
+    );
+
+    (new ClassWithPsOrderHooks())->hookActionValidateOrder(['order' => $order]);
+
+    /** @var PsOrderDataRepository $orderDataRepo */
+    $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
+    $record        = $orderDataRepo->findOneBy(['orderId' => $order->id]);
+
+    expect($record)->not->toBeNull();
+    $data = $record->getData();
+    expect($data)->toHaveKey('deliveryOptions');
+});
+
+it('does not create order data record when no cart delivery options exist', function () {
+    $cart  = psFactory(\Cart::class)->store();
+    $order = psFactory(Order::class)->withIdCart($cart->id)->store();
+
+    (new ClassWithPsOrderHooks())->hookActionValidateOrder(['order' => $order]);
+
+    /** @var PsOrderDataRepository $orderDataRepo */
+    $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
+    $record        = $orderDataRepo->findOneBy(['orderId' => $order->id]);
+
+    expect($record)->toBeNull();
+});
+
+it('does nothing when order param is missing', function () {
+    expect(fn() => (new ClassWithPsOrderHooks())->hookActionValidateOrder([]))->not->toThrow(\Throwable::class);
+});

--- a/tests/Unit/Hooks/HasPsOrderHooksTest.php
+++ b/tests/Unit/Hooks/HasPsOrderHooksTest.php
@@ -25,9 +25,11 @@ it('transfers delivery options from cart to order on validate', function () {
     $cart  = psFactory(\Cart::class)->store();
     $order = psFactory(Order::class)->withIdCart($cart->id)->store();
 
+    // Deliberately non-default values (not postnl / standard) so the test proves the actual
+    // stored options are round-tripped, and cannot pass on coincidentally-correct defaults.
     $rawDeliveryOptions = [
-        DeliveryOptions::CARRIER       => 'postnl',
-        DeliveryOptions::DELIVERY_TYPE => DeliveryOptions::DELIVERY_TYPE_STANDARD_NAME,
+        DeliveryOptions::CARRIER       => 'dpd',
+        DeliveryOptions::DELIVERY_TYPE => 'morning',
     ];
 
     /** @var PsCartDeliveryOptionsRepository $cartDeliveryOptionsRepo */

--- a/tests/Unit/Hooks/HasPsOrderHooksTest.php
+++ b/tests/Unit/Hooks/HasPsOrderHooksTest.php
@@ -49,7 +49,7 @@ it('transfers delivery options from cart to order on validate', function () {
     expect($data['deliveryOptions'])->toMatchArray($rawDeliveryOptions);
 });
 
-it('does not create order data record when no cart delivery options exist', function () {
+it('persists an empty order data record when no cart delivery options exist', function () {
     $cart  = psFactory(\Cart::class)->store();
     $order = psFactory(Order::class)->withIdCart($cart->id)->store();
 
@@ -59,7 +59,10 @@ it('does not create order data record when no cart delivery options exist', func
     $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
     $record        = $orderDataRepo->findOneBy(['orderId' => $order->id]);
 
-    expect($record)->toBeNull();
+    // Marks the order as "processed" even without delivery options, so getOrderData does
+    // not have to re-query the cart on every read.
+    expect($record)->not->toBeNull();
+    expect($record->getData())->toBe([]);
 });
 
 it('does nothing when order param is missing', function () {

--- a/tests/Unit/Hooks/HasPsOrderHooksTest.php
+++ b/tests/Unit/Hooks/HasPsOrderHooksTest.php
@@ -46,6 +46,7 @@ it('transfers delivery options from cart to order on validate', function () {
     expect($record)->not->toBeNull();
     $data = $record->getData();
     expect($data)->toHaveKey('deliveryOptions');
+    expect($data['deliveryOptions'])->toMatchArray($rawDeliveryOptions);
 });
 
 it('does not create order data record when no cart delivery options exist', function () {
@@ -62,5 +63,10 @@ it('does not create order data record when no cart delivery options exist', func
 });
 
 it('does nothing when order param is missing', function () {
-    expect(fn() => (new ClassWithPsOrderHooks())->hookActionValidateOrder([]))->not->toThrow(\Throwable::class);
+    (new ClassWithPsOrderHooks())->hookActionValidateOrder([]);
+
+    /** @var PsOrderDataRepository $orderDataRepo */
+    $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
+
+    expect($orderDataRepo->all())->toBeEmpty();
 });

--- a/tests/Unit/Service/PsOrderServiceTest.php
+++ b/tests/Unit/Service/PsOrderServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Service;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\PrestaShop\Contract\PsOrderServiceInterface;
+use MyParcelNL\PrestaShop\Repository\PsCartDeliveryOptionsRepository;
+use MyParcelNL\PrestaShop\Repository\PsOrderDataRepository;
+use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
+use Order;
+use function MyParcelNL\Pdk\Tests\usesShared;
+use function MyParcelNL\PrestaShop\psFactory;
+
+usesShared(new UsesMockPsPdkInstance());
+
+it('returns empty array and does NOT persist order data when no cart delivery options exist', function () {
+    $order = psFactory(\Order::class)->store();
+
+    /** @var PsOrderServiceInterface $orderService */
+    $orderService = Pdk::get(PsOrderServiceInterface::class);
+
+    $result = $orderService->getOrderData($order->id);
+
+    expect($result)->toBe([]);
+
+    /** @var PsOrderDataRepository $orderDataRepo */
+    $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
+    $record = $orderDataRepo->findOneBy(['orderId' => $order->id]);
+
+    expect($record)->toBeNull();
+});
+
+it('returns delivery options and persists order data when cart delivery options exist', function () {
+    $cart  = psFactory(\Cart::class)->store();
+    $order = psFactory(\Order::class)->withIdCart($cart->id)->store();
+
+    $rawDeliveryOptions = [
+        DeliveryOptions::CARRIER       => 'postnl',
+        DeliveryOptions::DELIVERY_TYPE => DeliveryOptions::DELIVERY_TYPE_STANDARD_NAME,
+    ];
+
+    /** @var PsCartDeliveryOptionsRepository $cartDeliveryOptionsRepo */
+    $cartDeliveryOptionsRepo = Pdk::get(PsCartDeliveryOptionsRepository::class);
+    $cartDeliveryOptionsRepo->updateOrCreate(
+        ['cartId' => $cart->id],
+        ['data'   => json_encode($rawDeliveryOptions)]
+    );
+
+    /** @var PsOrderServiceInterface $orderService */
+    $orderService = Pdk::get(PsOrderServiceInterface::class);
+
+    $result = $orderService->getOrderData($order->id);
+
+    expect($result)->toHaveKey('deliveryOptions');
+
+    /** @var PsOrderDataRepository $orderDataRepo */
+    $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
+    $record = $orderDataRepo->findOneBy(['orderId' => $order->id]);
+
+    expect($record)->not->toBeNull();
+});

--- a/tests/Unit/Service/PsOrderServiceTest.php
+++ b/tests/Unit/Service/PsOrderServiceTest.php
@@ -45,9 +45,12 @@ it('returns delivery options and persists order data when cart delivery options 
     // the latter resolves the carrier from the repository and throws
     // ModelNotFoundException in the PDK 4.0.1 mock environment. The code under test
     // stores the cart's raw data verbatim, so the exact shape here is what matters.
+    //
+    // Deliberately non-default values (not postnl / standard) so the test proves the actual
+    // stored options are round-tripped, and cannot pass on coincidentally-correct defaults.
     $rawDeliveryOptions = [
-        DeliveryOptions::CARRIER       => 'postnl',
-        DeliveryOptions::DELIVERY_TYPE => DeliveryOptions::DELIVERY_TYPE_STANDARD_NAME,
+        DeliveryOptions::CARRIER       => 'dpd',
+        DeliveryOptions::DELIVERY_TYPE => 'morning',
     ];
 
     /** @var PsCartDeliveryOptionsRepository $cartDeliveryOptionsRepo */

--- a/tests/Unit/Service/PsOrderServiceTest.php
+++ b/tests/Unit/Service/PsOrderServiceTest.php
@@ -38,6 +38,10 @@ it('returns delivery options and persists order data when cart delivery options 
     $cart  = psFactory(\Cart::class)->store();
     $order = psFactory(\Order::class)->withIdCart($cart->id)->store();
 
+    // A plain array literal is used instead of DeliveryOptions::toStorableArray():
+    // the latter resolves the carrier from the repository and throws
+    // ModelNotFoundException in the PDK 4.0.1 mock environment. The code under test
+    // stores the cart's raw data verbatim, so the exact shape here is what matters.
     $rawDeliveryOptions = [
         DeliveryOptions::CARRIER       => 'postnl',
         DeliveryOptions::DELIVERY_TYPE => DeliveryOptions::DELIVERY_TYPE_STANDARD_NAME,
@@ -56,6 +60,7 @@ it('returns delivery options and persists order data when cart delivery options 
     $result = $orderService->getOrderData($order->id);
 
     expect($result)->toHaveKey('deliveryOptions');
+    expect($result['deliveryOptions'])->toMatchArray($rawDeliveryOptions);
 
     /** @var PsOrderDataRepository $orderDataRepo */
     $orderDataRepo = Pdk::get(PsOrderDataRepository::class);

--- a/tests/Unit/Service/PsOrderServiceTest.php
+++ b/tests/Unit/Service/PsOrderServiceTest.php
@@ -17,7 +17,7 @@ use function MyParcelNL\PrestaShop\psFactory;
 
 usesShared(new UsesMockPsPdkInstance());
 
-it('returns empty array and does NOT persist order data when no cart delivery options exist', function () {
+it('persists an empty order data record when no cart delivery options exist', function () {
     $order = psFactory(\Order::class)->store();
 
     /** @var PsOrderServiceInterface $orderService */
@@ -27,11 +27,14 @@ it('returns empty array and does NOT persist order data when no cart delivery op
 
     expect($result)->toBe([]);
 
+    // The order is marked "processed" by persisting an empty record, so subsequent reads
+    // return the stored value instead of re-querying the cart on every getOrderData call.
     /** @var PsOrderDataRepository $orderDataRepo */
     $orderDataRepo = Pdk::get(PsOrderDataRepository::class);
     $record = $orderDataRepo->findOneBy(['orderId' => $order->id]);
 
-    expect($record)->toBeNull();
+    expect($record)->not->toBeNull();
+    expect($record->getData())->toBe([]);
 });
 
 it('returns delivery options and persists order data when cart delivery options exist', function () {

--- a/tests/__snapshots__/EntryTest__it_has_hooks__1.json
+++ b/tests/__snapshots__/EntryTest__it_has_hooks__1.json
@@ -17,5 +17,6 @@
     "displayHeader",
     "actionFilterDeliveryOptionList",
     "displayCarrierList",
-    "actionCarrierUpdate"
+    "actionCarrierUpdate",
+    "actionValidateOrder"
 ]


### PR DESCRIPTION
## Summary

Fixes [INT-1666](https://myparcelnl.atlassian.net/browse/INT-1666): delivery options chosen in checkout (carrier, signature, evening delivery, etc.) appeared as default PostNL / empty in the admin order grid for a variable delay after order creation, then eventually corrected themselves.

## Root cause

Delivery options are saved to a cart-keyed table (`myparcelnl_cart_delivery_options`) during checkout. The transfer to the order-keyed table (`myparcelnl_order_data`) happened **lazily** — only when `PsOrderService::getOrderData()` first ran (e.g. on the first admin grid render) did it read the cart and persist the result.

That first read could happen before the cart's delivery-options row was reliably readable, producing default/empty output. A record was then persisted, so subsequent reads returned the stored (empty) value until the data was eventually corrected.

## Fix

**Eager transfer** — a new `hookActionValidateOrder` hook (`HasPsOrderHooks` trait) transfers delivery options from cart to order at **order-validation time**, dispatched from `PaymentModule::validateOrder()` during checkout — before the order is ever accessible in the back-office. This is the actual fix: `actionValidateOrder` runs *after* the checkout step where the cart options were saved and committed, so the options are reliably present and there is no race.

An order-data record is **always persisted** — empty when the cart has no delivery options — to mark the order as processed, so `getOrderData()` returns the stored value instead of re-querying the cart on every read.

`PsOrderService` is unchanged from the baseline: `getFromCart()` remains as the lazy fallback (relevant only for orders created before this hook existed), and `getOrderNotes()` is untouched.

## Testing

- New `tests/Unit/Hooks/HasPsOrderHooksTest.php` — eager transfer when cart options exist, empty-record persistence when none, no-op when the `order` param is missing.
- New `tests/Unit/Service/PsOrderServiceTest.php` — persist-empty-on-miss and persist-on-hit paths (DB-backed).
- Hooks snapshot updated for the new `actionValidateOrder` hook.
- Full suite: 178 passed, 4 pre-existing skips.

## Note for release

`actionValidateOrder` is a newly registered hook — existing installs need a module upgrade/reinstall for PrestaShop to register it. Until then those shops rely on the lazy `getFromCart()` fallback.

[INT-1666]: https://myparcelnl.atlassian.net/browse/INT-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ