### PR TITLE
fix: show delivery options on initial checkout load

### DIFF
--- a/views/js/frontend/checkout/src/deliveryOptions/utils/updateDeliveryOptionsDiv.ts
+++ b/views/js/frontend/checkout/src/deliveryOptions/utils/updateDeliveryOptionsDiv.ts
@@ -2,6 +2,7 @@ import {useDeliveryOptionsStore} from '@myparcel-dev/pdk-checkout';
 import {getCurrentShippingMethod} from '../../utils';
 import {toggleDeliveryOptions} from './toggleDeliveryOptions';
 import {moveDeliveryOptionsForm} from './moveDeliveryOptionsForm';
+import {showDeliveryOptionsForm} from './showDeliveryOptionsForm';
 
 export const updateDeliveryOptionsDiv = (mode = 'move'): void => {
   const currentShippingMethod = getCurrentShippingMethod();
@@ -17,4 +18,8 @@ export const updateDeliveryOptionsDiv = (mode = 'move'): void => {
   void deliveryOptionsStore.set(newState);
 
   moveDeliveryOptionsForm(currentShippingMethod.row, mode);
+
+  if (newState.enabled) {
+    showDeliveryOptionsForm();
+  }
 };

--- a/views/js/frontend/checkout/src/initializeDeliveryOptions.ts
+++ b/views/js/frontend/checkout/src/initializeDeliveryOptions.ts
@@ -25,5 +25,5 @@ export const initializeDeliveryOptions = (): void => {
   checkoutStore.on(StoreListener.Update, onShippingMethodChange);
   deliveryOptionsStore.on(StoreListener.Update, onDeliveryOptionsOutputChange);
 
-  window.prestashop.on('updatedDeliveryForm', debounce(updateDeliveryOptionsDiv, 300));
+  window.prestashop.on('updatedDeliveryForm', debounce(() => updateDeliveryOptionsDiv(), 300));
 };

--- a/views/js/frontend/checkout/src/initializeDeliveryOptions.ts
+++ b/views/js/frontend/checkout/src/initializeDeliveryOptions.ts
@@ -10,7 +10,6 @@ import {
   getDefaultDeliveryOptionsConfig,
   onShippingMethodChange,
   onDeliveryOptionsOutputChange,
-  showDeliveryOptionsForm,
   updateDeliveryOptionsDiv,
 } from './deliveryOptions';
 
@@ -26,5 +25,5 @@ export const initializeDeliveryOptions = (): void => {
   checkoutStore.on(StoreListener.Update, onShippingMethodChange);
   deliveryOptionsStore.on(StoreListener.Update, onDeliveryOptionsOutputChange);
 
-  window.prestashop.on('updatedDeliveryForm', debounce(showDeliveryOptionsForm, 300));
+  window.prestashop.on('updatedDeliveryForm', debounce(updateDeliveryOptionsDiv, 300));
 };


### PR DESCRIPTION
## What & why

INT-1667 — In the PrestaShop checkout, the MyParcel Delivery Options widget was not rendered on initial page load when the **default/preselected carrier already supported delivery options**. It only appeared after a manual carrier switch, so customers who kept the (correct) default carrier never saw the delivery options.

## Root cause

Visibility was wired up so that on init, `updateDeliveryOptionsDiv()` computed the carrier-support (`enabled`) state and then `moveDeliveryOptionsForm()` **hid** the wrapper. The only function that *reveals* the wrapper, `showDeliveryOptionsForm()`, was wired **only** to PrestaShop's `updatedDeliveryForm` event — which fires on a carrier switch, never on initial load. So on load the wrapper was computed correctly and then hidden, with nothing to show it.

## Change

Make `updateDeliveryOptionsDiv` the **single source of truth** for wrapper visibility, driven by the `enabled` state:

- `updateDeliveryOptionsDiv.ts` — after moving the wrapper, call `showDeliveryOptionsForm()` when `newState.enabled` is true (non-D-O carriers stay hidden, as `moveDeliveryOptionsForm` already hides).
- `initializeDeliveryOptions.ts` — route the `updatedDeliveryForm` event through `updateDeliveryOptionsDiv` instead of the unconditional `showDeliveryOptionsForm`, and drop the now-unused import.

This also fixes a secondary inconsistency where `showDeliveryOptionsForm` previously revealed the wrapper unconditionally regardless of carrier support.

## Acceptance criteria

- [x] **AC1** Default carrier supports D-O → widget shown on load, no switch needed
- [x] **AC2** Default carrier does not support D-O → no widget (no regression)
- [x] **AC3** Switch non-D-O → D-O carrier → widget appears
- [x] **AC4** Switch D-O → non-D-O carrier → widget disappears
