### PR TITLE
fix: fix issues with stale cache causing issues when updating the plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "myparcelnl/pdk": "^4.1.1",
+    "myparcelnl/pdk": "^4.2.1",
     "myparcelnl/sdk": "^11.0.0-beta.28",
     "php": ">=7.4.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0af6a1b6ac19cf7de3b7ebcf0496bae8",
+    "content-hash": "0748505d305e9ed11bf3727a656c944b",
     "packages": [
         {
             "name": "fruitcake/php-cors",
@@ -471,16 +471,16 @@
         },
         {
             "name": "myparcelnl/pdk",
-            "version": "4.1.1",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "08913fe4eca2ddbd95b312dc162d145c0254644e"
+                "reference": "b77a3d55b508da849bc7ef743fb5959939583e89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/08913fe4eca2ddbd95b312dc162d145c0254644e",
-                "reference": "08913fe4eca2ddbd95b312dc162d145c0254644e",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/b77a3d55b508da849bc7ef743fb5959939583e89",
+                "reference": "b77a3d55b508da849bc7ef743fb5959939583e89",
                 "shasum": ""
             },
             "require": {
@@ -496,7 +496,7 @@
                 "behat/behat": "^3.13",
                 "brick/varexporter": "^0.4",
                 "guzzlehttp/guzzle": "^7.5",
-                "league/openapi-psr7-validator": "^0.22",
+                "league/openapi-psr7-validator": "^0.24",
                 "mockery/mockery": "^1.6",
                 "myparcelnl/devtools": "^1.0.0",
                 "nette/robot-loader": "^3.0.0",
@@ -527,9 +527,9 @@
             "homepage": "https://myparcel.nl",
             "support": {
                 "issues": "https://github.com/myparcelnl/pdk/issues",
-                "source": "https://github.com/myparcelnl/pdk/tree/v4.1.1"
+                "source": "https://github.com/myparcelnl/pdk/tree/v4.2.1"
             },
-            "time": "2026-07-07T08:25:04+00:00"
+            "time": "2026-07-09T14:23:19+00:00"
         },
         {
             "name": "myparcelnl/sdk",


### PR DESCRIPTION
- Fixes issues where the plugin would throw fatal errors due to outdated caches by updating PDK to 4.2.1
- Fixes open_basedir issues on hosts with symlinked webroots.
