### PR TITLE
fix(webhook): resolve order reference to order id in order mode v2 

### DIFF
--- a/src/Pdk/Order/Repository/PsPdkOrderRepository.php
+++ b/src/Pdk/Order/Repository/PsPdkOrderRepository.php
@@ -246,15 +246,16 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository implements P
      * Sales-channel (order mode v2) webhooks identify the order by the PrestaShop order
      * reference (e.g. "TILKNEGHQ") instead of the numeric order id. References are never fully
      * numeric, so non-numeric string input is resolved through Order::getByReference(); ids,
-     * numeric strings and models pass through untouched. An unknown reference falls through so
-     * get() raises its usual "Order not found".
+     * numeric strings and models pass through untouched. An unknown reference resolves to null
+     * so get() raises its usual "Order not found" — it must not fall back to the numeric-cast
+     * path, which would load an unrelated order for a digit-prefixed reference like "12AB".
      *
      * When a cart was split into multiple orders they share one reference; the first order is
      * used, matching the webhook's link-first-shipment-to-first-order behaviour.
      *
      * @param  string|int|\Order $input
      *
-     * @return string|int|\Order
+     * @return null|string|int|\Order
      */
     private function resolveOrderReference($input)
     {
@@ -265,7 +266,7 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository implements P
         $matches = PsOrder::getByReference($input)
             ->getResults();
 
-        return $matches[0] ?? $input;
+        return reset($matches) ?: null;
     }
 
     /**

--- a/src/Pdk/Order/Repository/PsPdkOrderRepository.php
+++ b/src/Pdk/Order/Repository/PsPdkOrderRepository.php
@@ -111,7 +111,7 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository implements P
     public function get($input): PdkOrder
     {
         /** @var \Order $psOrder */
-        $psOrder = $this->psOrderService->get($input);
+        $psOrder = $this->psOrderService->get($this->resolveOrderReference($input));
 
         if (! $psOrder) {
             throw new InvalidArgumentException('Order not found');
@@ -240,6 +240,32 @@ final class PsPdkOrderRepository extends AbstractPdkOrderRepository implements P
         }
 
         return $this->assembleOrders($basesByOrderId, ['notes' => []]);
+    }
+
+    /**
+     * Sales-channel (order mode v2) webhooks identify the order by the PrestaShop order
+     * reference (e.g. "TILKNEGHQ") instead of the numeric order id. References are never fully
+     * numeric, so non-numeric string input is resolved through Order::getByReference(); ids,
+     * numeric strings and models pass through untouched. An unknown reference falls through so
+     * get() raises its usual "Order not found".
+     *
+     * When a cart was split into multiple orders they share one reference; the first order is
+     * used, matching the webhook's link-first-shipment-to-first-order behaviour.
+     *
+     * @param  string|int|\Order $input
+     *
+     * @return string|int|\Order
+     */
+    private function resolveOrderReference($input)
+    {
+        if (! is_string($input) || '' === $input || ctype_digit($input)) {
+            return $input;
+        }
+
+        $matches = PsOrder::getByReference($input)
+            ->getResults();
+
+        return $matches[0] ?? $input;
     }
 
     /**

--- a/tests/Mock/MockPsOrder.php
+++ b/tests/Mock/MockPsOrder.php
@@ -6,6 +6,7 @@ namespace MyParcelNL\PrestaShop\Tests\Mock;
 
 use ObjectModel;
 use OrderState;
+use PrestaShopCollection;
 
 /**
  * @see \OrderCore
@@ -17,6 +18,30 @@ abstract class MockPsOrder extends ObjectModel
     protected static function getTable(): string
     {
         return 'orders';
+    }
+
+    /**
+     * Mirrors \OrderCore::getByReference(): a PrestaShopCollection holding the orders with the
+     * given reference. The reference filtering happens here because the mock collection only
+     * supports the primary-id "in" filter.
+     *
+     * @param  string $reference
+     *
+     * @return \PrestaShopCollection
+     */
+    public static function getByReference(string $reference): PrestaShopCollection
+    {
+        $ids = MockPsObjectModels::getByClass(static::class)
+            ->filter(function ($order) use ($reference) {
+                return $order->reference === $reference;
+            })
+            ->map(function ($order) {
+                return (int) $order->id;
+            })
+            ->values()
+            ->all();
+
+        return (new PrestaShopCollection(static::class))->where('id_order', 'in', $ids);
     }
 
     public function getCurrentOrderState(): ?OrderState

--- a/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
@@ -87,6 +87,34 @@ it('creates a pdk order from order id', function () {
     expect($pdkOrder)->toBeInstanceOf(PdkOrder::class);
 });
 
+it('creates a pdk order from order reference', function () {
+    /** @var Order $psOrder */
+    $psOrder = psFactory(Order::class)
+        ->withReference('TILKNEGHQ')
+        ->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $pdkOrder = $orderRepository->get('TILKNEGHQ');
+
+    expect($pdkOrder)
+        ->toBeInstanceOf(PdkOrder::class)
+        ->and((int) $pdkOrder->externalIdentifier)
+        ->toBe((int) $psOrder->id);
+});
+
+it('throws when order reference does not match any order', function () {
+    psFactory(Order::class)
+        ->withReference('TILKNEGHQ')
+        ->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $orderRepository->get('UNKNOWNREF');
+})->throws(InvalidArgumentException::class, 'Order not found');
+
 it('finds a pdk order by api identifier', function () {
     /** @var Order $psOrder */
     $psOrder = psFactory(Order::class)->store();

--- a/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Order/Repository/PdkOrderRepositoryTest.php
@@ -115,6 +115,19 @@ it('throws when order reference does not match any order', function () {
     $orderRepository->get('UNKNOWNREF');
 })->throws(InvalidArgumentException::class, 'Order not found');
 
+it('throws when an unknown reference starts with an existing order id', function () {
+    /** @var Order $psOrder */
+    $psOrder = psFactory(Order::class)
+        ->withReference('TILKNEGHQ')
+        ->store();
+
+    /** @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    // Must not be interpreted as "(int) '1AB'" and silently load order 1.
+    $orderRepository->get($psOrder->id . 'AB');
+})->throws(InvalidArgumentException::class, 'Order not found');
+
 it('finds a pdk order by api identifier', function () {
     /** @var Order $psOrder */
     $psOrder = psFactory(Order::class)->store();


### PR DESCRIPTION
In order mode v2 the sales channel identifies orders by the PrestaShop order reference(e.g. "TILKNEGHQ"), and that's what ends up in the webhook's shipment_reference_identifier. PrestaShop has both an Order ID and a Reference. The plugin used that reference directly as the numeric order id, so the order lookup failed and incoming shipment webhooks crashed ("Webhook failed" in the logs, no barcode/status on the order). WooCommerce doesn't have this problem because its order ids are numeric.

Fix: `PsPdkOrderRepository::get() `now resolves (non-numeric) string input via `Order::getByReference() `before loading the order. Ids, numeric strings and Order models pass through untouched, so export/grid/v1 behaviour stays the same. Uknown references still throw 'Order not found'.

Potential follow-up for the pdk (separate PR): log the exception message in `PdkWebhookManager`, right now webhook failures are logged without a reason.

Fixes INT-1537 and INT-1536