### PR TITLE
fix(insurance): refresh stored carrier data so we stop using depreated insurance amounts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "myparcelnl/pdk": "^4.7.0",
+    "myparcelnl/pdk": "^4.7.4",
     "myparcelnl/sdk": "^11.0.0-beta.28",
     "php": ">=7.4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "myparcelnl/pdk": "^4.6.0",
+    "myparcelnl/pdk": "^4.7.0",
     "myparcelnl/sdk": "^11.0.0-beta.28",
     "php": ">=7.4.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ef3587913d6169a2906dee0e291ae2b",
+    "content-hash": "91999e85f4b2b870d7c5c99ed0f972d3",
     "packages": [
         {
             "name": "fruitcake/php-cors",
@@ -4783,5 +4783,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91999e85f4b2b870d7c5c99ed0f972d3",
+    "content-hash": "fd0cadaf14601d7a8ae44113441b29bc",
     "packages": [
         {
             "name": "fruitcake/php-cors",
@@ -471,16 +471,16 @@
         },
         {
             "name": "myparcelnl/pdk",
-            "version": "4.7.2",
+            "version": "4.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "a09bcabdb311b48e0a8ddae0eb58274b85f20e69"
+                "reference": "17a4165408c5b46efb1136f5a7f90c7022af88a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/a09bcabdb311b48e0a8ddae0eb58274b85f20e69",
-                "reference": "a09bcabdb311b48e0a8ddae0eb58274b85f20e69",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/17a4165408c5b46efb1136f5a7f90c7022af88a8",
+                "reference": "17a4165408c5b46efb1136f5a7f90c7022af88a8",
                 "shasum": ""
             },
             "require": {
@@ -527,9 +527,9 @@
             "homepage": "https://myparcel.nl",
             "support": {
                 "issues": "https://github.com/myparcelnl/pdk/issues",
-                "source": "https://github.com/myparcelnl/pdk/tree/v4.7.2"
+                "source": "https://github.com/myparcelnl/pdk/tree/v4.7.4"
             },
-            "time": "2026-08-12T09:40:29+00:00"
+            "time": "2026-08-19T11:14:15+00:00"
         },
         {
             "name": "myparcelnl/sdk",
@@ -4773,15 +4773,15 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4.0"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@myparcel-dev/eslint-config-prettier": "^1.4.0",
     "@myparcel-dev/eslint-config-prettier-typescript": "^1.4.0",
     "@myparcel-dev/eslint-config-prettier-typescript-vue": "^1.4.0",
-    "@myparcel-dev/pdk-app-builder": "^4.1.0",
+    "@myparcel-dev/pdk-app-builder": "^4.1.3",
     "@myparcel-dev/sdk": "^5.0.0",
     "@myparcel-dev/semantic-release-config": "^6.0.10",
     "@types/node": "^20.0.0",

--- a/src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php
+++ b/src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\App\Installer\Migration\AbstractTimestampedMigration;
+use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Pdk;
+
+/**
+ * Re-fetches the stored carrier data so insurance limits are in the flat format.
+ *
+ * Carrier data stored before this release holds insurance limits in the nested wrapper the
+ * MyParcel API is removing. The PDK now reads the flat limits, which are absent from that older
+ * data, so insurance would be unavailable until something refreshed it. Fetching the contract
+ * definitions again rewrites the stored carriers in the shape the PDK expects.
+ */
+return new class extends AbstractTimestampedMigration {
+    public function up(): void
+    {
+        /** @var PdkAccountRepositoryInterface $accountRepository */
+        $accountRepository = Pdk::get(PdkAccountRepositoryInterface::class);
+        $account           = $accountRepository->getAccount(true);
+        // PHPStan types Account::$shops as a non-null ShopCollection, but the guard is kept
+        // intentionally to stay safe against partial/corrupted account data during upgrade.
+        // @phpstan-ignore booleanAnd.rightAlwaysTrue
+        $shop = $account && $account->shops ? $account->shops->first() : null;
+
+        if (! $shop) {
+            Logger::debug('No account or shop available; skipping carrier capabilities refresh.');
+
+            return;
+        }
+
+        /** @var CarrierCapabilitiesRepository $capabilitiesRepository */
+        $capabilitiesRepository = Pdk::get(CarrierCapabilitiesRepository::class);
+
+        try {
+            $shop->carriers = $capabilitiesRepository->getContractDefinitions();
+        } catch (Throwable $exception) {
+            // Re-throw so the migration is not marked as applied, letting it retry on the next
+            // load instead of leaving the carriers on the old shape.
+            Logger::warning('Failed to refresh carrier capabilities; migration will retry.', [
+                'exception' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        }
+
+        $accountRepository->store($account);
+    }
+};

--- a/src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php
+++ b/src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php
@@ -24,7 +24,6 @@ return new class extends AbstractTimestampedMigration {
         $account           = $accountRepository->getAccount(true);
         // PHPStan types Account::$shops as a non-null ShopCollection, but the guard is kept
         // intentionally to stay safe against partial/corrupted account data during upgrade.
-        // @phpstan-ignore booleanAnd.rightAlwaysTrue
         $shop = $account && $account->shops ? $account->shops->first() : null;
 
         if (! $shop) {
@@ -42,7 +41,10 @@ return new class extends AbstractTimestampedMigration {
             // Re-throw so the migration is not marked as applied, letting it retry on the next
             // load instead of leaving the carriers on the old shape.
             Logger::warning('Failed to refresh carrier capabilities; migration will retry.', [
-                'exception' => $exception->getMessage(),
+                'message' => $exception->getMessage(),
+                'file'    => $exception->getFile() . ':' . $exception->getLine(),
+                'class'   => get_class($exception),
+                'trace'   => $exception->getTraceAsString(),
             ]);
 
             throw $exception;

--- a/src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php
+++ b/src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php
@@ -38,16 +38,16 @@ return new class extends AbstractTimestampedMigration {
         try {
             $shop->carriers = $capabilitiesRepository->getContractDefinitions();
         } catch (Throwable $exception) {
-            // Re-throw so the migration is not marked as applied, letting it retry on the next
-            // load instead of leaving the carriers on the old shape.
-            Logger::warning('Failed to refresh carrier capabilities; migration will retry.', [
+            // Reporting failure leaves the migration unrecorded, so it is attempted again on the
+            // next load. Throwing would do that too, but it would take the page down with it.
+            $this->markFailed('Failed to refresh carrier capabilities.', [
                 'message' => $exception->getMessage(),
                 'file'    => $exception->getFile() . ':' . $exception->getLine(),
                 'class'   => get_class($exception),
                 'trace'   => $exception->getTraceAsString(),
             ]);
 
-            throw $exception;
+            return;
         }
 
         $accountRepository->store($account);

--- a/src/Pdk/Base/PsPdkBootstrapper.php
+++ b/src/Pdk/Base/PsPdkBootstrapper.php
@@ -112,6 +112,13 @@ class PsPdkBootstrapper extends PdkBootstrapper
             'carrierLogoFileExtensions' => value(['.png', '.jpg']),
 
             /**
+             * Migrations
+             */
+
+            // The pdk defaults this to its own package root, where no module migration lives.
+            'migrationDirectory' => value(sprintf('%s/src/Migration', rtrim($path, '/'))),
+
+            /**
              * The symfony routes that are used by the pdk. Must match the routes in config/routes.yml.
              *
              * @see config/routes.yml

--- a/tests/Bootstrap/MockPsPdkBootstrapper.php
+++ b/tests/Bootstrap/MockPsPdkBootstrapper.php
@@ -10,6 +10,7 @@ use MyParcelNL\Pdk\Base\Concern\PdkInterface;
 use MyParcelNL\Pdk\Base\Contract\ConfigInterface;
 use MyParcelNL\Pdk\Base\FileSystemInterface;
 use MyParcelNL\Pdk\Language\Contract\LanguageServiceInterface;
+use MyParcelNL\Pdk\SdkApi\Contract\SdkClientFactoryInterface;
 use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
 use MyParcelNL\Pdk\Storage\MemoryCacheStorage;
 use MyParcelNL\Pdk\Tests\Api\Guzzle7ClientAdapter;
@@ -20,6 +21,7 @@ use MyParcelNL\Pdk\Tests\Bootstrap\MockLanguageService;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockLogger;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockMemoryCacheStorage;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockPdk;
+use MyParcelNL\Pdk\Tests\SdkApi\MockSdkClientFactory;
 use MyParcelNL\PrestaShop\Pdk\Base\PsPdkBootstrapper;
 use MyParcelNL\PrestaShop\Tests\Bootstrap\Contract\StaticMockInterface;
 use Psr\Log\LoggerInterface;
@@ -80,6 +82,9 @@ final class MockPsPdkBootstrapper extends PsPdkBootstrapper implements StaticMoc
                 PdkInterface::class             => get(MockPdk::class),
                 StorageInterface::class         => get(MockMemoryCacheStorage::class),
                 LanguageServiceInterface::class => get(MockLanguageService::class),
+                // Covers every SdkApi service at once, the same way the client adapter above
+                // covers every legacy API service. Without it they reach the live API.
+                SdkClientFactoryInterface::class => get(MockSdkClientFactory::class),
             ],
             self::$config
         );

--- a/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
+++ b/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
@@ -56,8 +56,11 @@ it('skips without failing when no account or shop is available', function () {
     expect($accountRepo->getAccount())->toBeNull();
 });
 
-it('rethrows when fetching carrier definitions fails so the migration retries', function () {
+it('reports failure instead of throwing when fetching carrier definitions fails', function () {
     TestBootstrapper::hasAccount();
+    // The migration forces an account refresh before it gets as far as the carriers. Without a
+    // response queued that call throws, and the test would pass on the wrong exception.
+    MockApi::enqueue(new ExampleGetAccountsResponse());
 
     $throwingRepo = new class(
         Pdk::get(StorageInterface::class),
@@ -71,9 +74,13 @@ it('rethrows when fetching carrier definitions fails so the migration retries', 
 
     mockPdkProperties([CarrierCapabilitiesRepository::class => $throwingRepo]);
 
-    // Throwing is the only way to retry: the installer marks a migration as applied straight
-    // after up() returns, so swallowing the error would strand the old carrier data.
-    expect(fn() => loadRefreshCarrierCapabilitiesMigration()->up())->toThrow(RuntimeException::class);
+    $migration = loadRefreshCarrierCapabilitiesMigration();
+    $migration->up();
+
+    // Reporting failure keeps the migration out of applied_migrations, so it is attempted again
+    // on the next load. Reaching this line at all is the other half of the point: a carrier API
+    // that is briefly unavailable no longer takes the page down with it.
+    expect($migration->hasFailed())->toBeTrue();
 });
 
 dataset('insurance shapes from the api', [

--- a/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
+++ b/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Migration;
+
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\App\Installer\Contract\TimestampedMigrationInterface;
+use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
+use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService;
+use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
+use MyParcelNL\Pdk\Tests\Api\Response\ExampleGetAccountsResponse;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockApi;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\SdkApi\MockSdkApiHandler;
+use MyParcelNL\Pdk\Tests\SdkApi\Response\ExampleContractDefinitionsResponse;
+use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
+use RuntimeException;
+use function MyParcelNL\Pdk\Tests\mockPdkProperties;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPsPdkInstance());
+
+/**
+ * Loads the migration the same way the installer does: require the file and take the
+ * returned anonymous-class instance.
+ */
+function loadRefreshCarrierCapabilitiesMigration(): TimestampedMigrationInterface
+{
+    return require __DIR__ . '/../../../src/Migration/2026_07_29_113506_refresh_carrier_capabilities.php';
+}
+
+it('is a timestamped migration the installer can discover', function () {
+    $migration = loadRefreshCarrierCapabilitiesMigration();
+
+    // The installer injects identity from the filename, so the migration must accept it
+    // and report it back rather than deriving one itself.
+    $migration->setIdentity('2026_07_29_113506_refresh_carrier_capabilities');
+
+    expect($migration)->toBeInstanceOf(TimestampedMigrationInterface::class)
+        ->and($migration->getId())->toBe('2026_07_29_113506_refresh_carrier_capabilities');
+});
+
+it('skips without failing when no account or shop is available', function () {
+    /** @var PdkAccountRepositoryInterface $accountRepo */
+    $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
+
+    // No account configured, so a forced refresh returns null. Skipping beats fataling:
+    // a fresh install has nothing to refresh.
+    loadRefreshCarrierCapabilitiesMigration()->up();
+
+    expect($accountRepo->getAccount())->toBeNull();
+});
+
+it('rethrows when fetching carrier definitions fails so the migration retries', function () {
+    TestBootstrapper::hasAccount();
+
+    $throwingRepo = new class(
+        Pdk::get(StorageInterface::class),
+        Pdk::get(CapabilitiesService::class)
+    ) extends CarrierCapabilitiesRepository {
+        public function getContractDefinitions(?string $carrier = null): CarrierCollection
+        {
+            throw new RuntimeException('API unavailable');
+        }
+    };
+
+    mockPdkProperties([CarrierCapabilitiesRepository::class => $throwingRepo]);
+
+    // Throwing is the only way to retry: the installer marks a migration as applied straight
+    // after up() returns, so swallowing the error would strand the old carrier data.
+    expect(fn() => loadRefreshCarrierCapabilitiesMigration()->up())->toThrow(RuntimeException::class);
+});
+
+dataset('insurance shapes from the api', [
+    // What the API sends today. The nested wrapper carries different amounts, so if the wrong
+    // set of limits ever survived, the assertions below would catch it.
+    'flat limits alongside the deprecated nested wrapper' => [
+        [
+            'min'           => ['amount' => 0, 'currency' => 'EUR'],
+            'max'           => ['amount' => 500_000, 'currency' => 'EUR'],
+            'default'       => ['amount' => 0, 'currency' => 'EUR'],
+            'insuredAmount' => [
+                'min'     => ['amount' => 1, 'currency' => 'EUR'],
+                'max'     => ['amount' => 2, 'currency' => 'EUR'],
+                'default' => ['amount' => 3, 'currency' => 'EUR'],
+            ],
+        ],
+    ],
+    // What the API sends once the nested wrapper is removed.
+    'flat limits only'                                   => [
+        [
+            'min'     => ['amount' => 0, 'currency' => 'EUR'],
+            'max'     => ['amount' => 500_000, 'currency' => 'EUR'],
+            'default' => ['amount' => 0, 'currency' => 'EUR'],
+        ],
+    ],
+]);
+
+it('stores only the flat insurance limits', function (array $insurance) {
+    TestBootstrapper::hasAccount();
+    // The migration forces an account refresh, which calls the accounts endpoint.
+    MockApi::enqueue(new ExampleGetAccountsResponse());
+    // Goes through the real CapabilitiesService and repository, so the nested wrapper is
+    // dropped by the code that actually does it rather than by a stub.
+    MockSdkApiHandler::enqueue(new ExampleContractDefinitionsResponse([
+        [
+            'carrier'          => 'POSTNL',
+            'packageTypes'     => ['PACKAGE'],
+            'deliveryTypes'    => ['STANDARD_DELIVERY'],
+            'transactionTypes' => ['B2C'],
+            'options'          => [
+                'insurance' => array_merge(
+                    ['isSelectedByDefault' => false, 'isRequired' => false],
+                    $insurance
+                ),
+            ],
+        ],
+    ]));
+
+    loadRefreshCarrierCapabilitiesMigration()->up();
+
+    /** @var PdkAccountRepositoryInterface $accountRepo */
+    $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
+    $carrier     = $accountRepo->getAccount()
+        ->shops->first()
+        ->carriers->firstWhere('carrier', 'POSTNL');
+    $stored      = $carrier->options->getInsurance();
+
+    // Same stored result either way: the flat limits, and no nested wrapper left behind.
+    expect($stored->getInsuredAmount())->toBeNull()
+        ->and($stored->getMin()->getAmount())->toBe(0)
+        ->and($stored->getMax()->getAmount())->toBe(500_000)
+        ->and($stored->getDefault()->getAmount())->toBe(0);
+})->with('insurance shapes from the api');

--- a/tests/Unit/Pdk/Installer/Service/PsInstallerServiceTest.php
+++ b/tests/Unit/Pdk/Installer/Service/PsInstallerServiceTest.php
@@ -12,6 +12,7 @@ use MyParcelNL\Pdk\Base\Contract\Arrayable;
 use MyParcelNL\Pdk\Base\Support\Collection;
 use MyParcelNL\Pdk\Facade\Installer;
 use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use MyParcelNL\PrestaShop\Facade\MyParcelModule;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsDb;
 use MyParcelNL\PrestaShop\Tests\Mock\MockPsObjectModels;
@@ -111,4 +112,23 @@ it('installs: doesn\'t add same tab twice', function () {
     expect($tabRepository->findByModule(\MyParcelNL::MODULE_NAME))->toHaveCount(1);
     Installer::install($module);
     expect($tabRepository->findByModule(\MyParcelNL::MODULE_NAME))->toHaveCount(1);
+});
+
+it('installs: records the timestamped migrations of the module', function () {
+    /** @var \MyParcelNL $module */
+    $module = Pdk::get('moduleInstance');
+
+    $timestamped = array_map(function (string $path): string {
+        return pathinfo($path, PATHINFO_FILENAME);
+    }, glob(__DIR__ . '/../../../../../src/Migration/[0-9]*.php') ?: []);
+
+    // Guards the assertion below against passing on an empty set.
+    expect($timestamped)->not->toBeEmpty();
+
+    Installer::install($module);
+
+    /** @var \MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface $settings */
+    $settings = Pdk::get(PdkSettingsRepositoryInterface::class);
+
+    expect($settings->get(Pdk::get('settingKeyAppliedMigrations')))->toContain(...$timestamped);
 });

--- a/views/js/backend/admin/package.json
+++ b/views/js/backend/admin/package.json
@@ -11,13 +11,13 @@
     "test:run": "run ws:test:run \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-admin": "^2.2.0",
-    "@myparcel-dev/pdk-admin-preset-bootstrap4": "^2.2.0",
-    "@myparcel-dev/pdk-admin-preset-default": "^2.2.0",
+    "@myparcel-dev/pdk-admin": "^2.2.2",
+    "@myparcel-dev/pdk-admin-preset-bootstrap4": "^2.2.2",
+    "@myparcel-dev/pdk-admin-preset-default": "^2.2.2",
     "@myparcel-dev/ts-utils": "^1.15.0"
   },
   "devDependencies": {
-    "@myparcel-dev/pdk-admin-component-tests": "^2.2.0",
+    "@myparcel-dev/pdk-admin-component-tests": "^2.2.2",
     "@vitejs/plugin-vue": "^5.0.0",
     "@vitest/coverage-v8": "^1.0.0",
     "autoprefixer": "^10.4.14",

--- a/views/js/frontend/checkout/package.json
+++ b/views/js/frontend/checkout/package.json
@@ -11,7 +11,7 @@
     "test:run": "run ws:test:run \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.0"
+    "@myparcel-dev/pdk-checkout": "^2.1.3"
   },
   "devDependencies": {
     "@myparcel-prestashop/vite-config": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampproject/remapping@npm:^2.2.1, @ampproject/remapping@npm:^2.3.0":
+"@ampproject/remapping@npm:^2.2.1":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
   dependencies:
@@ -99,6 +99,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.24.7, @babel/parser@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": "npm:^7.29.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/acc890c5e6a6dd40863a47b50bac111d7185ee6fbbe163ebe11d5214854ca2adb901462ad4d718a65090ef84bd2230e9e8ab45a2e0caccc685f1f57ab0bb1e28
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.25.4":
   version: 7.26.1
   resolution: "@babel/parser@npm:7.26.1"
@@ -121,28 +132,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/parser@npm:7.29.7"
-  dependencies:
-    "@babel/types": "npm:^7.29.7"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.29.8":
-  version: 7.29.8
-  resolution: "@babel/parser@npm:7.29.8"
-  dependencies:
-    "@babel/types": "npm:^7.29.8"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/acc890c5e6a6dd40863a47b50bac111d7185ee6fbbe163ebe11d5214854ca2adb901462ad4d718a65090ef84bd2230e9e8ab45a2e0caccc685f1f57ab0bb1e28
-  languageName: node
-  linkType: hard
-
 "@babel/types@npm:^7.25.4, @babel/types@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/types@npm:7.26.0"
@@ -160,16 +149,6 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: 10c0/39d556be114f2a6d874ea25ad39826a9e3a0e98de0233ae6d932f6d09a4b222923a90a7274c635ed61f1ba49bbd345329226678800900ad1c8d11afabd573aaf
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/types@npm:7.29.7"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.29.7"
-    "@babel/helper-validator-identifier": "npm:^7.29.7"
-  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -966,13 +945,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
-  checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
-  languageName: node
-  linkType: hard
-
 "@jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
@@ -1000,15 +972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ljharb/through@npm:^2.3.9":
-  version: 2.3.11
-  resolution: "@ljharb/through@npm:2.3.11"
-  dependencies:
-    call-bind: "npm:^1.0.2"
-  checksum: 10c0/19cdaa9e4ba16aea9bb9dafbdd1c111febc0e5ce07b0959b049d7fda8a7247726603bb06b391f2d57227cf4ad081636d6f9e08dc138813225d54a6c81a04b679
-  languageName: node
-  linkType: hard
-
 "@myparcel-dev/constants@npm:^2.10.0, @myparcel-dev/constants@npm:^2.7.0, @myparcel-dev/constants@npm:^2.9.0":
   version: 2.10.0
   resolution: "@myparcel-dev/constants@npm:2.10.0"
@@ -1018,39 +981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@myparcel-dev/delivery-options@npm:^6.25.0":
-  version: 6.26.1
-  resolution: "@myparcel-dev/delivery-options@npm:6.26.1"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.9.0"
-    "@myparcel-dev/do-shared": "npm:^6.26.1"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
-    "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@vueuse/core": "npm:^10.0.0"
-    leaflet: "npm:^1.9.4"
-    radash: "npm:^12.0.0"
-    vue: "npm:^3.5.26"
-  checksum: 10c0/51bac53a2d1e9c5981f3994b85162dba61fe9b1547af4d3e84273f7aef0525adadb6ac4bc7c2325c013e5e560456be8900bbbaa1d975405b09e4013982be2480
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/delivery-options@npm:^7.0.0":
-  version: 7.4.0
-  resolution: "@myparcel-dev/delivery-options@npm:7.4.0"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.10.0"
-    "@myparcel-dev/do-shared": "npm:^7.4.0"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
-    "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@vueuse/core": "npm:^10.0.0"
-    leaflet: "npm:^1.9.4"
-    radash: "npm:^12.0.0"
-    vue: "npm:^3.5.26"
-  checksum: 10c0/6e99d84d1ee3a1d9858f474236098a6d70a93d720eb4b4a163ce11fb8b12bfdec99dace1e5f9ebf78f623d9367b8dee9e434cf2c5651521640e9e70abb84c902
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/delivery-options@npm:^7.4.3":
+"@myparcel-dev/delivery-options@npm:^7.5.0":
   version: 7.5.0
   resolution: "@myparcel-dev/delivery-options@npm:7.5.0"
   dependencies:
@@ -1063,42 +994,6 @@ __metadata:
     radash: "npm:^12.0.0"
     vue: "npm:^3.5.26"
   checksum: 10c0/e9111baf69d10216d6c2f1a9f73382a92f0f62ea0bd42166197a155ce03f8fbec580bacca77106fee656b31b9704f4d453d4b9662df27cd87496235c42c87869
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/do-shared@npm:^6.26.1":
-  version: 6.26.1
-  resolution: "@myparcel-dev/do-shared@npm:6.26.1"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.9.0"
-    "@myparcel-dev/do-shared": "npm:^6.26.1"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
-    "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@vueuse/core": "npm:^10.6.0"
-    date-fns: "npm:^3.0.0"
-    pinia: "npm:^2.1.7"
-    radash: "npm:^12.0.0"
-    vue: "npm:^3.5.26"
-    vue-tsc: "npm:^3.2.2"
-  checksum: 10c0/90b505e636e252062db57c51e941766253b7b1a9ab0f62b42a12308ddf066251556fa96821d1c70901ab4aafffdfc8bb35205a4dc0ebef3bb6a859e2ba570e3b
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/do-shared@npm:^7.4.0":
-  version: 7.4.0
-  resolution: "@myparcel-dev/do-shared@npm:7.4.0"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.10.0"
-    "@myparcel-dev/do-shared": "npm:^7.4.0"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
-    "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@vueuse/core": "npm:^10.6.0"
-    date-fns: "npm:^3.0.0"
-    pinia: "npm:^2.1.7"
-    radash: "npm:^12.0.0"
-    vue: "npm:^3.5.26"
-    vue-tsc: "npm:^3.2.2"
-  checksum: 10c0/dd0f6a7d534ea6eff8b831f593ba953fff6050e95a2909b0f08bb4a484328b00ffd258d56ba9ace1dd7d070a7a2c6c47d5f493d6b42dece58c57a52095dcb61d
   languageName: node
   linkType: hard
 
@@ -1281,53 +1176,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin-component-tests@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin-component-tests@npm:2.2.0"
+"@myparcel-dev/pdk-admin-component-tests@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin-component-tests@npm:2.2.2"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
     "@pinia/testing": "npm:>= 0.1.0 < 1"
-    "@vitest/coverage-v8": "npm:^2.1.3"
     "@vue/test-utils": "npm:^2.0.0"
-    happy-dom: "npm:^14.0.0"
     pinia: "npm:^2.0.0"
     vitest: "npm:^3.2.6"
   peerDependencies:
-    vue: 3.5.40
-  checksum: 10c0/96802eccf8f358114d8855a5932c0b5443230c95f7112c6917ace71816cededbaaca92471301740c280a212086b9d3bc47219eeff50befefdea1880293b9ccda
+    vue: 3.4.31
+  checksum: 10c0/494c90aff41f506fb2bbca8dee18d6607e328a300d1dd319fe9a8f47f2e487d813fc3a9b4066eaf6e5bc8c8c91778fce0f367e802484a34889c3f53c63879905
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin-preset-bootstrap4@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin-preset-bootstrap4@npm:2.2.0"
+"@myparcel-dev/pdk-admin-preset-bootstrap4@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin-preset-bootstrap4@npm:2.2.2"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    vue: "npm:3.5.40"
-  checksum: 10c0/248627079c1de576733b5b7d3962bfc32744bd1514f700aa9217aa16f3e7dc11977b1ced075879b743d9c98047562a17d1e01c55ddf1e7d41b160b647578b8b0
+    vue: "npm:3.4.31"
+  checksum: 10c0/9a0a4cedcd353d59cbbfb3af0ee96c77890bb4b467aec4a996c1b94f7dd5b055fcf5aef74203fc6e33d129bded8aae6a9f7a5d1f4f1b1237d7191bdef6c0d2de
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin-preset-default@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin-preset-default@npm:2.2.0"
+"@myparcel-dev/pdk-admin-preset-default@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin-preset-default@npm:2.2.2"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@vuepic/vue-datepicker": "npm:^11.0.2"
     "@vueuse/core": "npm:^10.0.0"
-    vue: "npm:3.5.40"
-  checksum: 10c0/951a2a03b7d68b8c1f082094ed888b1f0dfba8c298667007c90dc37d0637f0b15b46f9dc8180470daf8e5e963350f5cc89fc768b89811d660036dd00dba8358e
+    vue: "npm:3.4.31"
+  checksum: 10c0/edd7c4acd0f1991cb2094b73c8b749d85fbede2331483af81c675a90a7a88c5495441817cda7ad32ca9ba04cf85664e5e6a1327b96dcfeaf9136e5d9e01739df
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin@npm:2.2.0"
+"@myparcel-dev/pdk-admin@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin@npm:2.2.2"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.9.0"
-    "@myparcel-dev/pdk-common": "npm:^2.1.0"
+    "@myparcel-dev/pdk-common": "npm:^2.1.2"
     "@myparcel-dev/sdk": "npm:^5.1.0"
     "@myparcel-dev/vue-form-builder": "npm:1.0.0-beta.42.6"
     "@tanstack/vue-query": "npm:~4.43.0"
@@ -1336,97 +1229,90 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     lodash-unified: "npm:^1.0.3"
     pinia: "npm:^2.0.0"
-    vite: "npm:^5.4.10"
-    vue: "npm:3.5.40"
-    vue-tsc: "npm:^3.3.9"
-  checksum: 10c0/490b24f11cafd5eceeace17569730f709ce45af03eff897a94a16a66998dbc5102e2e251bb4ba4bb7487236696c34ee717ed352e5a3f1b97c0912c6e0e5ee900
+    vue: "npm:3.4.31"
+  checksum: 10c0/1ce74ea9217e6d1b9ca2c01f89f450d2e635095c5e0d3b6700840390d704c460f7f9010b54700f72ada3af5d229268c9920d575c3d6741077ee3985f69d4bd33
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-app-builder@npm:^4.1.0":
-  version: 4.1.2
-  resolution: "@myparcel-dev/pdk-app-builder@npm:4.1.2"
+"@myparcel-dev/pdk-app-builder@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@myparcel-dev/pdk-app-builder@npm:4.1.3"
   dependencies:
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    chalk: "npm:^5.2.0"
+    chalk: "npm:^6.0.0"
     commander: "npm:^12.0.0"
     debug: "npm:^4.3.4"
-    inquirer: "npm:^9.1.4"
     interpret: "npm:^3.1.1"
     liftoff: "npm:^5.0.0"
     mypa-google-docs-importer: "npm:^1.0.1"
     radash: "npm:^12.1.0"
-    semver: "npm:^7.5.4"
-    supports-color: "npm:^11.0.0"
   bin:
     pdk-builder: ./bin/index.js
-  checksum: 10c0/f23d07b2f51461481f41c5bb391b0e64223215066b141bb4cfdbc31669e29787c7f1f4c503eb04d18106b36d587fbff90759231389e57cc4b75e7be699e10aa2
+  checksum: 10c0/2971cc27bd2de26fc33e576cb869308d71854eac2ee5097f47f9d97704c6b7cd98e0693d9f22dd6aa1062e883023ea32a11c81008e6b7beda5d2cf0b6c891c29
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-common@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-checkout-common@npm:2.1.0"
+"@myparcel-dev/pdk-checkout-common@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-common@npm:2.1.3"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.7.0"
-    "@myparcel-dev/delivery-options": "npm:^7.4.3"
-    "@myparcel-dev/pdk-common": "npm:^2.1.0"
-    typescript: "npm:^5.2.2"
-  checksum: 10c0/8462a9b2cc3e272125e998e99b0cfcdaa18a29c69fdb48eb0591d239e8afe5888e812cb3e9c7c39d4f403f781e0327554d1e08d731e95052ff62dd5ab9d25f5f
+    "@myparcel-dev/delivery-options": "npm:^7.5.0"
+    "@myparcel-dev/pdk-common": "npm:^2.1.2"
+    radash: "npm:^12.1.0"
+  checksum: 10c0/27a02da43388892ca62c9e15b298c9e44501ccc376ca85111c19db14917fcfbae4467d10552053959a27e81c3960f23e77e1c6716872e540615099f3b5b3bf38
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-delivery-options@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-checkout-delivery-options@npm:2.1.0"
+"@myparcel-dev/pdk-checkout-delivery-options@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-delivery-options@npm:2.1.3"
   dependencies:
-    "@myparcel-dev/delivery-options": "npm:^7.0.0"
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.0"
+    "@myparcel-dev/delivery-options": "npm:^7.5.0"
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
-  checksum: 10c0/cbd3086ab240b15b1eb3051e5aaa8f5493f665ac7c759ffddd8268a96a17aae1185f5848301a63a446b150900252682999b71925431f30d54b31dc7c41ec6a05
+  checksum: 10c0/c27158b0cd22d7fc218e9b463f235a9603f49da913b1ed7c3056b06372ccff4d756829aa7a34602b2ea92dcd2e5be177028183b69df96895dbc2fe0fa7704edf
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-separate-address-fields@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-checkout-separate-address-fields@npm:2.1.0"
+"@myparcel-dev/pdk-checkout-separate-address-fields@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-separate-address-fields@npm:2.1.3"
   dependencies:
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.0"
-  checksum: 10c0/20bb091ac862eae1e4df567127718c75452d5377dc51c5bb6aef1f92b46ad48ab3ac064f161747477b2e555b1253c577be580d9230fbf5cf8b173d12ebab998e
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
+  checksum: 10c0/0aefc39a60e7367a341a257c46da0509571085b0671bde14e7db5ec0200b9262abc36b2be50633ab5208ddbc5c07e080deb0fd77aa6e0c921f516593b8a47909
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-tax-fields@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-checkout-tax-fields@npm:2.1.0"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.7.0"
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.0"
-  checksum: 10c0/1fcd9d7a41fe9c0bfe1ad30a5f269c31a69b399838dd6ca0cbc41a2e09ca5f19b9e1997509d62c10b90f526333a330d5495d02594806dacfb1e6f4dec7181885
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/pdk-checkout@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-checkout@npm:2.1.0"
-  dependencies:
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.0"
-    "@myparcel-dev/pdk-checkout-delivery-options": "npm:^2.1.0"
-    "@myparcel-dev/pdk-checkout-separate-address-fields": "npm:^2.1.0"
-    "@myparcel-dev/pdk-checkout-tax-fields": "npm:^2.1.0"
-    "@myparcel-dev/pdk-common": "npm:^2.1.0"
-  checksum: 10c0/874b4327db073940b4b185c4d517c5a827970af027812c6ab485a2ebf06492deb1ff6b92111230dfa1e328c3bfbc83809b90c497d2f0dfaa2f5be9c4cdd938e4
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/pdk-common@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-common@npm:2.1.0"
+"@myparcel-dev/pdk-checkout-tax-fields@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-tax-fields@npm:2.1.3"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.7.0"
-    "@myparcel-dev/delivery-options": "npm:^6.25.0"
-  checksum: 10c0/85f2fb01fc896afa8c3f0acda77b44f918e830aa09eb3baca2c420973b3de5b9ea5377924509f59dc6fac658e2ca6b4fd8218bbd2ed7c39f1c1d59f21dd7de27
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
+  checksum: 10c0/6ed73e505629206892334a7388a867bd50c9373b646b5b5079158ae5f35f2905a3dade35cdbb2e79d2890d19dcbad6bdfaa8edf7b84317b12ed37c359993135b
+  languageName: node
+  linkType: hard
+
+"@myparcel-dev/pdk-checkout@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout@npm:2.1.3"
+  dependencies:
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-delivery-options": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-separate-address-fields": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-tax-fields": "npm:^2.1.3"
+  checksum: 10c0/a73cf17da47238aea09a38adab5ed5d9b7c0117b10a907512a55bc3432aa34bd163dc4fdc9142028f5beda5a75ae8ec65325561ce56e684fdddffacaa867fe48
+  languageName: node
+  linkType: hard
+
+"@myparcel-dev/pdk-common@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@myparcel-dev/pdk-common@npm:2.1.2"
+  dependencies:
+    "@myparcel-dev/constants": "npm:^2.7.0"
+    "@myparcel-dev/delivery-options": "npm:^7.5.0"
+  checksum: 10c0/b696de2d6dcb1d1209d765acdba1b9339c1fa009ee44c66a7e9714bb74d6f4293093f9af5f45d9421b957d1282755e494d8d7557623f5ff69b908b4f8272949d
   languageName: node
   linkType: hard
 
@@ -1494,10 +1380,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-prestashop/backend-admin@workspace:views/js/backend/admin"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
-    "@myparcel-dev/pdk-admin-component-tests": "npm:^2.2.0"
-    "@myparcel-dev/pdk-admin-preset-bootstrap4": "npm:^2.2.0"
-    "@myparcel-dev/pdk-admin-preset-default": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
+    "@myparcel-dev/pdk-admin-component-tests": "npm:^2.2.2"
+    "@myparcel-dev/pdk-admin-preset-bootstrap4": "npm:^2.2.2"
+    "@myparcel-dev/pdk-admin-preset-default": "npm:^2.2.2"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@vitejs/plugin-vue": "npm:^5.0.0"
     "@vitest/coverage-v8": "npm:^1.0.0"
@@ -1519,7 +1405,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-prestashop/frontend-checkout@workspace:views/js/frontend/checkout"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.0"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
     "@myparcel-prestashop/vite-config": "workspace:*"
     "@types/jquery": "npm:^3.5.16"
     vite: "npm:^5.0.0"
@@ -1537,7 +1423,7 @@ __metadata:
     "@myparcel-dev/eslint-config-prettier": "npm:^1.4.0"
     "@myparcel-dev/eslint-config-prettier-typescript": "npm:^1.4.0"
     "@myparcel-dev/eslint-config-prettier-typescript-vue": "npm:^1.4.0"
-    "@myparcel-dev/pdk-app-builder": "npm:^4.1.0"
+    "@myparcel-dev/pdk-app-builder": "npm:^4.1.3"
     "@myparcel-dev/sdk": "npm:^5.0.0"
     "@myparcel-dev/semantic-release-config": "npm:^6.0.10"
     "@types/node": "npm:^20.0.0"
@@ -3496,32 +3382,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^2.1.3":
-  version: 2.1.4
-  resolution: "@vitest/coverage-v8@npm:2.1.4"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.3.0"
-    "@bcoe/v8-coverage": "npm:^0.2.3"
-    debug: "npm:^4.3.7"
-    istanbul-lib-coverage: "npm:^3.2.2"
-    istanbul-lib-report: "npm:^3.0.1"
-    istanbul-lib-source-maps: "npm:^5.0.6"
-    istanbul-reports: "npm:^3.1.7"
-    magic-string: "npm:^0.30.12"
-    magicast: "npm:^0.3.5"
-    std-env: "npm:^3.7.0"
-    test-exclude: "npm:^7.0.1"
-    tinyrainbow: "npm:^1.2.0"
-  peerDependencies:
-    "@vitest/browser": 2.1.4
-    vitest: 2.1.4
-  peerDependenciesMeta:
-    "@vitest/browser":
-      optional: true
-  checksum: 10c0/f795fdd645ccc46de45baa431a1b3b216d74195b9751cb0498009b8ef929dcd48c2f858570d421908549f5a631ac2931f7c7f3fe4ff0bc80707805beda5c18d7
-  languageName: node
-  linkType: hard
-
 "@vitest/expect@npm:1.6.1":
   version: 1.6.1
   resolution: "@vitest/expect@npm:1.6.1"
@@ -3686,6 +3546,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-core@npm:3.4.31"
+  dependencies:
+    "@babel/parser": "npm:^7.24.7"
+    "@vue/shared": "npm:3.4.31"
+    entities: "npm:^4.5.0"
+    estree-walker: "npm:^2.0.2"
+    source-map-js: "npm:^1.2.0"
+  checksum: 10c0/17833fa55af0168da4ec79b1233aba2bf6df9a88cd95be513a122f3433901e70284ce467a504a36547debdf49f887cf807734360a7660fd8f7622bf15c74b01d
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-core@npm:3.5.17":
   version: 3.5.17
   resolution: "@vue/compiler-core@npm:3.5.17"
@@ -3696,19 +3569,6 @@ __metadata:
     estree-walker: "npm:^2.0.2"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/d6b50f6f0a71a77a04452877c601cfd6ea13ec07aa68a061523166c1150e159f64230eee28e1042e6113e334a11c25c306bae5d463931a9e7f96261a29a0042d
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-core@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-core@npm:3.5.40"
-  dependencies:
-    "@babel/parser": "npm:^7.29.7"
-    "@vue/shared": "npm:3.5.40"
-    entities: "npm:^7.0.1"
-    estree-walker: "npm:^2.0.2"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/695744e23cebf18bef6fc07d51d76c173dcbb79829a10cd0424b3e7ea540ef400974ecc8d0dfd684955c1d16b47adbd33fcc01d04eef2c9d549c415d4b3b7a9d
   languageName: node
   linkType: hard
 
@@ -3725,13 +3585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-dom@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-dom@npm:3.5.40"
+"@vue/compiler-dom@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-dom@npm:3.4.31"
   dependencies:
-    "@vue/compiler-core": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/2b8a6d89fac89f1b880c18004a392b190555d9a5c882b804755a560c8ca84eefa771015c757d478dcd3323c0ea5a34025a7a641a06434a80ee4b978d8fd011ed
+    "@vue/compiler-core": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/136b2208685d7d67e282a7da5f377f40878c467832789be21aadbe322832541aa20a4e2d0c5faa57b4f5608067eeb680d123fdb08c2ef9b28f0d6a94a3d79dbc
   languageName: node
   linkType: hard
 
@@ -3755,20 +3615,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-sfc@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-sfc@npm:3.5.40"
+"@vue/compiler-sfc@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-sfc@npm:3.4.31"
   dependencies:
-    "@babel/parser": "npm:^7.29.7"
-    "@vue/compiler-core": "npm:3.5.40"
-    "@vue/compiler-dom": "npm:3.5.40"
-    "@vue/compiler-ssr": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
+    "@babel/parser": "npm:^7.24.7"
+    "@vue/compiler-core": "npm:3.4.31"
+    "@vue/compiler-dom": "npm:3.4.31"
+    "@vue/compiler-ssr": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
     estree-walker: "npm:^2.0.2"
-    magic-string: "npm:^0.30.21"
-    postcss: "npm:^8.5.19"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7cbdacee87c2fd20087747ef95a4a52d7406cb24b76757a7734f7d3efe88292623e81a706a5ca9e626ed3e160dedb4a01a302ecf7707db7ebd7b16a2fb01f11c
+    magic-string: "npm:^0.30.10"
+    postcss: "npm:^8.4.38"
+    source-map-js: "npm:^1.2.0"
+  checksum: 10c0/b8983a52dd3d5d7f9640dbda5946f01fcb92213a6c3a9a76d1df8f67fd43c59402ab6ff4211a205bf91155c4cd2a45fb39c36a83199bc1256eaeb9f690895b73
   languageName: node
   linkType: hard
 
@@ -3789,13 +3649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-ssr@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-ssr@npm:3.5.40"
+"@vue/compiler-ssr@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-ssr@npm:3.4.31"
   dependencies:
-    "@vue/compiler-dom": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/934fcfc2e0b18ce1239bb47db9155f6533eda39e90f56f6a0a4bcb79755dc3fdebe771555496bf043ec54f62f52664085a935725d8e479873481c08dabff4ee9
+    "@vue/compiler-dom": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/8083959c21b344f8ee5029c0ea91d50118a32b7c7c430971a721785b0349ce92d82d9cf17d7991a283f79b4ec1c68db4d1d182e035c17aa9116aa07ee115bac0
   languageName: node
   linkType: hard
 
@@ -3849,12 +3709,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/reactivity@npm:3.5.40"
+"@vue/reactivity@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/reactivity@npm:3.4.31"
   dependencies:
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/cbefefe6aee3fce6cdf04fcb8c36eab0b47581af499b51a3b19fe9358ab98366b1edd38fefe6059b38284879053656c4e4c0656396426880f255c90eada8b443
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/974ce9c9f26367845d71ab37aa5644b06f5e8e938ebe343004a8cb700505350da70fd315f39aecc46ffa62c474e3fb947529bd3981b66efab8ab45c34189a334
   languageName: node
   linkType: hard
 
@@ -3867,13 +3727,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/runtime-core@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/runtime-core@npm:3.5.40"
+"@vue/runtime-core@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/runtime-core@npm:3.4.31"
   dependencies:
-    "@vue/reactivity": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/e1dada4b25a4467073dd71516dcf8be4224c571df36a5b7dd193c6a12171c0c0ae7645fbb3d508ddd417af472b10e1c10c1efe70cdce99b7da03558e6bcd6119
+    "@vue/reactivity": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/446711364e34520d5f38133950ecb27ede0d235fabb74237b51dc6ef22cce1b5db94033acbf6fc485c2dd3034862492eb247d267487bd36c88cb4ad151ffaf3c
   languageName: node
   linkType: hard
 
@@ -3887,15 +3747,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/runtime-dom@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/runtime-dom@npm:3.5.40"
+"@vue/runtime-dom@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/runtime-dom@npm:3.4.31"
   dependencies:
-    "@vue/reactivity": "npm:3.5.40"
-    "@vue/runtime-core": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-    csstype: "npm:^3.2.3"
-  checksum: 10c0/a397ee1e7964fe7791a3e6456c7bd0a3c85c6c156971a172cfabba5009457885b14060c7aad12c7db7f6f0f35c0d94921b45314994b010e2b454a44b89e9a281
+    "@vue/reactivity": "npm:3.4.31"
+    "@vue/runtime-core": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+    csstype: "npm:^3.1.3"
+  checksum: 10c0/4c0b20f16ad3a676d1a61b07f24d1668166e5b0cc133344eafcecde308952d577005fc4a1fa77fd055dffce5dbacbd4577688f2dc151ac0f2f6e1d31529fdfc6
   languageName: node
   linkType: hard
 
@@ -3911,14 +3771,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/server-renderer@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/server-renderer@npm:3.5.40"
+"@vue/server-renderer@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/server-renderer@npm:3.4.31"
   dependencies:
-    "@vue/compiler-ssr": "npm:3.5.40"
-    "@vue/runtime-dom": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/b991a7b0a03c9e4d1968e62d64495d988c0ed027826ac2be02b1461db42fdebaa80dd950132d0fedb96c4511eab6940d83799faa769d6f10945ad0c1f839ad75
+    "@vue/compiler-ssr": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  peerDependencies:
+    vue: 3.4.31
+  checksum: 10c0/1e01142c2f7b6ee9b1e94a25142452fc60ef7fbdd47b4c145db001fbfd20e5c9fab97a74d7c0978b4a0beacc043f330524623b22f1bd7faa353c41feb824c549
   languageName: node
   linkType: hard
 
@@ -3933,17 +3794,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/shared@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/shared@npm:3.4.31"
+  checksum: 10c0/45643c0c7aa6b208891aac5798629ee5b982a5e52343c0a23ecc15b7aeb580b606ce78e70daee0fd691ccddb5f10196c4d56c7da4b8716157be1772a43f1c45e
+  languageName: node
+  linkType: hard
+
 "@vue/shared@npm:3.5.17, @vue/shared@npm:^3.5.0":
   version: 3.5.17
   resolution: "@vue/shared@npm:3.5.17"
   checksum: 10c0/915d8f80d863826531cf6ddefeb52455cbffcbca4d14717472b7765b3142d2ad9900dfce351e90a22e1fe9e2f8fca588421de6e751e1c816ab9e1fdefa3e8a0d
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/shared@npm:3.5.40"
-  checksum: 10c0/b18346d3936d2c7b16d01a7c77b0b95fac19f4427bb17e5c968ea4e1c752df5d3f4f2db70b26a28fe033f81522f3cb83ccd13713f4e4f861fedba915b0b3f825
   languageName: node
   linkType: hard
 
@@ -4066,16 +3927,6 @@ __metadata:
     js-yaml: "npm:^3.10.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/c7f421c6885142f351459031c093fb2e79abcce6f4a89765a10e600bb7ab122949c54bcea2b23de9572a2b34ba29f822b17831c1c43ba50373ceb8cb5b336667
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/parsers@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/parsers@npm:3.0.0"
-  dependencies:
-    js-yaml: "npm:^3.10.0"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/cec2c6dd6e7f926e9f7de6c2d8551261fece40295f2bb2b333f47c88559094aead266750f4963809f7fded3bd9f642f194b4e0bb87a847e191761004a790533a
   languageName: node
   linkType: hard
 
@@ -4241,15 +4092,6 @@ __metadata:
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
-  languageName: node
-  linkType: hard
-
-"ansi-escapes@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "ansi-escapes@npm:4.3.2"
-  dependencies:
-    type-fest: "npm:^0.21.3"
-  checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
   languageName: node
   linkType: hard
 
@@ -4614,7 +4456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.3, bl@npm:^4.1.0":
+"bl@npm:^4.0.3":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -4914,10 +4756,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chardet@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "chardet@npm:0.7.0"
-  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
+"chalk@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "chalk@npm:6.0.0"
+  checksum: 10c0/47fd9028aa66fa532295525fe3ac5aec5e467e0d86847d4b5f6e01f9c9bb70b6fd1edca79cddc78a0f31a357baa65cc752d30c6557d025904207d113c82d8962
   languageName: node
   linkType: hard
 
@@ -5082,13 +4924,6 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^7.0.0"
   checksum: 10c0/d7f0b73e3d9b88cb496e6c086df7410b541b56a43d18ade6a573c9c18bd001b1c3fba1ad578f741a4218fdc794d042385f8ac02c25e1c295a2d8b9f3cb86eb4c
-  languageName: node
-  linkType: hard
-
-"cli-width@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "cli-width@npm:4.1.0"
-  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
   languageName: node
   linkType: hard
 
@@ -5436,7 +5271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.2.3":
+"csstype@npm:^3.1.3, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -5529,18 +5364,6 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "debug@npm:4.3.7"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
   languageName: node
   linkType: hard
 
@@ -6669,17 +6492,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"external-editor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "external-editor@npm:3.1.0"
-  dependencies:
-    chardet: "npm:^0.7.0"
-    iconv-lite: "npm:^0.4.24"
-    tmp: "npm:^0.0.33"
-  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -7310,22 +7122,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.4.1":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^3.1.2"
-    minimatch: "npm:^9.0.4"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^1.11.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
-  languageName: node
-  linkType: hard
-
 "glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -7484,17 +7280,6 @@ __metadata:
   bin:
     handlebars: bin/handlebars
   checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
-  languageName: node
-  linkType: hard
-
-"happy-dom@npm:^14.0.0":
-  version: 14.7.1
-  resolution: "happy-dom@npm:14.7.1"
-  dependencies:
-    entities: "npm:^4.5.0"
-    webidl-conversions: "npm:^7.0.0"
-    whatwg-mimetype: "npm:^3.0.0"
-  checksum: 10c0/546a16921cde2cad91a35eefc936eb26df444d95e976e01276052e5fd2db3a8dd5864182475ebbfc8443689ce306246d8e6dfec40bab5fb8bc99e2a448b795e9
   languageName: node
   linkType: hard
 
@@ -7781,15 +7566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -7910,29 +7686,6 @@ __metadata:
     validate-npm-package-license: "npm:^3.0.4"
     validate-npm-package-name: "npm:^5.0.0"
   checksum: 10c0/bf23946580af21edb07cb2847516625f361775b2f7b26d53ef629fe6cf920b491d41e63343419c89567999e7e568396f98ec107b733ac3679e52222f518ee28b
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:^9.1.4":
-  version: 9.2.11
-  resolution: "inquirer@npm:9.2.11"
-  dependencies:
-    "@ljharb/through": "npm:^2.3.9"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^5.3.0"
-    cli-cursor: "npm:^3.1.0"
-    cli-width: "npm:^4.1.0"
-    external-editor: "npm:^3.1.0"
-    figures: "npm:^5.0.0"
-    lodash: "npm:^4.17.21"
-    mute-stream: "npm:1.0.0"
-    ora: "npm:^5.4.1"
-    run-async: "npm:^3.0.0"
-    rxjs: "npm:^7.8.1"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 10c0/4bc2db9a3c04432ba6f10b236b1975c5e112d42c2364ffa62e1b5bca5d3d358e7bee0c4d2b5b50294d05a8b452b66cf274b25b5d3c4a71df6c90c372102dee8a
   languageName: node
   linkType: hard
 
@@ -8607,7 +8360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-source-maps@npm:^5.0.4, istanbul-lib-source-maps@npm:^5.0.6":
+"istanbul-lib-source-maps@npm:^5.0.4":
   version: 5.0.6
   resolution: "istanbul-lib-source-maps@npm:5.0.6"
   dependencies:
@@ -8628,16 +8381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-reports@npm:^3.1.7":
-  version: 3.1.7
-  resolution: "istanbul-reports@npm:3.1.7"
-  dependencies:
-    html-escaper: "npm:^2.0.0"
-    istanbul-lib-report: "npm:^3.0.0"
-  checksum: 10c0/a379fadf9cf8dc5dfe25568115721d4a7eb82fbd50b005a6672aff9c6989b20cc9312d7865814e0859cd8df58cbf664482e1d3604be0afde1f7fc3ccc1394a51
-  languageName: node
-  linkType: hard
-
 "jackspeak@npm:^2.3.6":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
@@ -8648,19 +8391,6 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10c0/f01d8f972d894cd7638bc338e9ef5ddb86f7b208ce177a36d718eac96ec86638a6efa17d0221b10073e64b45edc2ce15340db9380b1f5d5c5d000cbc517dc111
-  languageName: node
-  linkType: hard
-
-"jackspeak@npm:^3.1.2":
-  version: 3.4.3
-  resolution: "jackspeak@npm:3.4.3"
-  dependencies:
-    "@isaacs/cliui": "npm:^8.0.2"
-    "@pkgjs/parseargs": "npm:^0.11.0"
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 10c0/6acc10d139eaefdbe04d2f679e6191b3abf073f111edf10b1de5302c97ec93fffeb2fdd8681ed17f16268aa9dd4f8c588ed9d1d3bffbbfa6e8bf897cbb3149b9
   languageName: node
   linkType: hard
 
@@ -9236,7 +8966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
+"log-symbols@npm:^4.0.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
@@ -9305,16 +9035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.12":
-  version: 0.30.12
-  resolution: "magic-string@npm:0.30.12"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
-  checksum: 10c0/469f457d18af37dfcca8617086ea8a65bcd8b60ba8a1182cb024ce43e470ace3c9d1cb6bee58d3b311768fb16bc27bd50bdeebcaa63dadd0fd46cac4d2e11d5f
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
+"magic-string@npm:^0.30.10, magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -9332,7 +9053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magicast@npm:^0.3.3, magicast@npm:^0.3.5":
+"magicast@npm:^0.3.3":
   version: 0.3.5
   resolution: "magicast@npm:0.3.5"
   dependencies:
@@ -9589,7 +9310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -9766,7 +9487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:1.0.0, mute-stream@npm:~1.0.0":
+"mute-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "mute-stream@npm:1.0.0"
   checksum: 10c0/dce2a9ccda171ec979a3b4f869a102b1343dee35e920146776780de182f16eae459644d187e38d59a3d37adf85685e1c17c38cf7bfda7e39a9880f7a1d10a74c
@@ -10520,30 +10241,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ora@npm:^5.4.1":
-  version: 5.4.1
-  resolution: "ora@npm:5.4.1"
-  dependencies:
-    bl: "npm:^4.1.0"
-    chalk: "npm:^4.1.0"
-    cli-cursor: "npm:^3.1.0"
-    cli-spinners: "npm:^2.5.0"
-    is-interactive: "npm:^1.0.0"
-    is-unicode-supported: "npm:^0.1.0"
-    log-symbols: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-    wcwidth: "npm:^1.0.1"
-  checksum: 10c0/10ff14aace236d0e2f044193362b22edce4784add08b779eccc8f8ef97195cae1248db8ec1ec5f5ff076f91acbe573f5f42a98c19b78dba8c54eefff983cae85
-  languageName: node
-  linkType: hard
-
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
-  languageName: node
-  linkType: hard
-
 "own-keys@npm:^1.0.1":
   version: 1.0.1
   resolution: "own-keys@npm:1.0.1"
@@ -10718,13 +10415,6 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: 10c0/c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
-  languageName: node
-  linkType: hard
-
-"package-json-from-dist@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "package-json-from-dist@npm:1.0.1"
-  checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
   languageName: node
   linkType: hard
 
@@ -10939,16 +10629,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.11.1":
-  version: 1.11.1
-  resolution: "path-scurry@npm:1.11.1"
-  dependencies:
-    lru-cache: "npm:^10.2.0"
-    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
-  checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
-  languageName: node
-  linkType: hard
-
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -11159,7 +10839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.43, postcss@npm:^8.5.19, postcss@npm:^8.5.6":
+"postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.38, postcss@npm:^8.4.43, postcss@npm:^8.5.19, postcss@npm:^8.5.6":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:
@@ -11897,28 +11577,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"run-async@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "run-async@npm:3.0.0"
-  checksum: 10c0/b18b562ae37c3020083dcaae29642e4cc360c824fbfb6b7d50d809a9d5227bb986152d09310255842c8dce40526e82ca768f02f00806c91ba92a8dfa6159cb85
-  languageName: node
-  linkType: hard
-
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
   dependencies:
     queue-microtask: "npm:^1.2.2"
   checksum: 10c0/200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:^7.8.1":
-  version: 7.8.1
-  resolution: "rxjs@npm:7.8.1"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/3c49c1ecd66170b175c9cacf5cef67f8914dcbc7cd0162855538d365c83fea631167cacb644b3ce533b2ea0e9a4d0b12175186985f89d75abe73dbd8f7f06f68
   languageName: node
   linkType: hard
 
@@ -11993,7 +11657,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -12587,13 +12251,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "std-env@npm:3.7.0"
-  checksum: 10c0/60edf2d130a4feb7002974af3d5a5f3343558d1ccf8d9b9934d225c638606884db4a20d2fe6440a09605bca282af6b042ae8070a10490c0800d69e82e478f41e
-  languageName: node
-  linkType: hard
-
 "std-env@npm:^3.9.0":
   version: 3.10.0
   resolution: "std-env@npm:3.10.0"
@@ -12861,13 +12518,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "supports-color@npm:11.0.0"
-  checksum: 10c0/f89d815d18d5508da54db73d762fa6d6418bced383694a4e05a56331075069010d9f501e6755b14617a00317553a498f07281933be72428eff136dbfe6a80128
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -12999,17 +12649,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"test-exclude@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "test-exclude@npm:7.0.1"
-  dependencies:
-    "@istanbuljs/schema": "npm:^0.1.2"
-    glob: "npm:^10.4.1"
-    minimatch: "npm:^9.0.4"
-  checksum: 10c0/6d67b9af4336a2e12b26a68c83308c7863534c65f27ed4ff7068a56f5a58f7ac703e8fc80f698a19bb154fd8f705cdf7ec347d9512b2c522c737269507e7b263
-  languageName: node
-  linkType: hard
-
 "text-extensions@npm:^1.0.0":
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"
@@ -13120,13 +12759,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyrainbow@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "tinyrainbow@npm:1.2.0"
-  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
-  languageName: node
-  linkType: hard
-
 "tinyrainbow@npm:^2.0.0":
   version: 2.0.0
   resolution: "tinyrainbow@npm:2.0.0"
@@ -13145,15 +12777,6 @@ __metadata:
   version: 4.0.4
   resolution: "tinyspy@npm:4.0.4"
   checksum: 10c0/a8020fc17799251e06a8398dcc352601d2770aa91c556b9531ecd7a12581161fd1c14e81cbdaff0c1306c93bfdde8ff6d1c1a3f9bbe6d91604f0fd4e01e2f1eb
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
   languageName: node
   linkType: hard
 
@@ -13228,7 +12851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.3.0, tslib@npm:^2.4.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
@@ -13295,13 +12918,6 @@ __metadata:
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
   checksum: 10c0/dea9df45ea1f0aaa4e2d3bed3f9a0bfe9e5b2592bddb92eb1bf06e50bcf98dbb78189668cd8bc31a0511d3fc25539b4cd5c704497e53e93e2d40ca764b10bfc3
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^0.21.3":
-  version: 0.21.3
-  resolution: "type-fest@npm:0.21.3"
-  checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
   languageName: node
   linkType: hard
 
@@ -13447,7 +13063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.4, typescript@npm:^5.2.2":
+"typescript@npm:^5.0.4":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -13457,7 +13073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -13760,49 +13376,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.4.10":
-  version: 5.4.10
-  resolution: "vite@npm:5.4.10"
-  dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.43"
-    rollup: "npm:^4.20.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/4ef4807d2fd166a920de244dbcec791ba8a903b017a7d8e9f9b4ac40d23f8152c1100610583d08f542b47ca617a0505cfc5f8407377d610599d58296996691ed
-  languageName: node
-  linkType: hard
-
 "vitest@npm:^1.0.0":
   version: 1.6.1
   resolution: "vitest@npm:1.6.1"
@@ -13988,7 +13561,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-tsc@npm:^3.0.4, vue-tsc@npm:^3.2.2, vue-tsc@npm:^3.3.9":
+"vue-tsc@npm:^3.0.4, vue-tsc@npm:^3.2.2":
   version: 3.3.9
   resolution: "vue-tsc@npm:3.3.9"
   dependencies:
@@ -14002,21 +13575,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:3.5.40":
-  version: 3.5.40
-  resolution: "vue@npm:3.5.40"
+"vue@npm:3.4.31":
+  version: 3.4.31
+  resolution: "vue@npm:3.4.31"
   dependencies:
-    "@vue/compiler-dom": "npm:3.5.40"
-    "@vue/compiler-sfc": "npm:3.5.40"
-    "@vue/runtime-dom": "npm:3.5.40"
-    "@vue/server-renderer": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
+    "@vue/compiler-dom": "npm:3.4.31"
+    "@vue/compiler-sfc": "npm:3.4.31"
+    "@vue/runtime-dom": "npm:3.4.31"
+    "@vue/server-renderer": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
   peerDependencies:
     typescript: "*"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/89a455e8fef36096c05e9e504457ec2210d9cd0f2966a229ec84d1d52bc98028a749c8675571fe0caaf1022c59628ef2fe627f1b4fe48f7b491a995ebd5b4ebb
+  checksum: 10c0/d9d7ac45f2f9b69b3c2f1cabf2d70cad4e829f7daebc2d2896b5e2e58074fee002d870691cfeb12af891ce1bedac2318269dffc4c581319823ed5e5e9173cd03
   languageName: node
   linkType: hard
 
@@ -14259,17 +13832,6 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "wrap-ansi@npm:6.2.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
refreshes the stored carrier data on update so insurance keeps working when the API changes format, and stops unit tests calling the live API.

Carrier data stored before this release holds insurance limits in the nested wrapper the MyParcel API is removing (Core API story SB-2770). The PDK now reads the flat limits, which that older data does not have, so insurance would be unavailable in the shop until something refreshed it.

Adds a timestamped migration that fetches the contract definitions again and rewrites the stored carriers in the shape the PDK expects. It runs once per install, tracked by identity rather than plugin version. When the API cannot be reached the migration reports failure through the PDK's `markFailed()`, so it stays unrecorded and is retried on the next load without taking the page down. PrestaShop runs migrations in the request, with no background worker to fall back on, so throwing meant a merchant hitting the same fatal on every load until the API recovered.

Tested against both formats the API can send: the flat limits on their own, and the flat limits alongside the deprecated nested wrapper as it sends today. Both store the same thing, with no nested wrapper left behind. The test drives the real capabilities service rather than a stub, so it is the actual behaviour being exercised.

Separately, the first commit fixes something that turned up while writing that test. The bootstrapper mocks the client adapter, which covers the legacy API layer, but the SdkApi services built their own HTTP client and slipped past it — so any test touching capabilities, shipping rule implications or whoami sent a real request to the live API, surfacing as a 401 rather than a useful failure. Those services now take their transport through the constructor, so one binding points all of them at the mock queue, including any service added later. Worth a look on its own: it affects every test in the module, not just this migration.

Now on PDK 4.7.0, which carries the injectable transport (myparcelnl/pdk#512) and `markFailed()` (myparcelnl/pdk#519).

Still to do before this can be released: myparcelnl/pdk#511 for the flat insurance format has to merge and ship. Until it does, the `flat limits alongside the deprecated nested wrapper` test stays red, because the PDK does not drop the nested wrapper yet. With #511 merged locally the whole suite passes: 196 passing, 4 skipped, and no outbound host contacted.

Resolves INT-1699
Part of INT-1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)
