### PR TITLE
ci(dependabot): widen myparcel cooldown exclusions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,8 +45,10 @@ updates:
     open-pull-requests-limit: 20
     cooldown:
       exclude:
-          - "@myparcel-pdk/*"
-          - "@myparcel-dev/pdk-*"
+        - "@myparcel/*"
+        - "@myparcel-dev/*"
+        - "@myparcel-eslint/*"
+        - "@myparcel-pdk/*"
     groups:
       minor-js-updates:
         applies-to: version-updates


### PR DESCRIPTION
This change widens the Dependabot cooldown exclusions to cover all our own npm packages.

The npm exclude list held only the pdk packages, so our other packages still waited out the 3-day cooldown. It now covers every scope we publish. `@myparcel-dev/*` replaces `@myparcel-dev/pdk-*`, which it already covers, so the exclusions stay a superset of the previous list. This change also corrects the indentation of the list.

Patterns are matched with `File.fnmatch?` against the full dependency name, so a scope glob such as `@myparcel-dev/*` matches every package in that scope.

Part of aligning all repos with 3b76767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
