### PR TITLE
fix(installer): keep the upgrade available until migrations finish

### DIFF
--- a/src/Hooks/HasModuleUpgradeOverrides.php
+++ b/src/Hooks/HasModuleUpgradeOverrides.php
@@ -6,6 +6,7 @@ namespace MyParcelNL\PrestaShop\Hooks;
 
 use MyParcelNL;
 use MyParcelNL\Pdk\Base\FileSystemInterface;
+use MyParcelNL\Pdk\Facade\Installer;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
 use Throwable;
@@ -23,6 +24,24 @@ trait HasModuleUpgradeOverrides
      */
     public static function upgradeModuleVersion($name, $version): bool
     {
+        // Leave the registered version behind while migrations still have work. canBeUpgraded()
+        // compares it with the version on disk, so PrestaShop keeps offering the upgrade and the
+        // merchant can run it again to finish. Bumping it here would hide the button and strand
+        // whatever is left unconverted.
+        //
+        // There is no limit on the number of attempts, on purpose. A shop whose migration cannot
+        // finish keeps being offered the upgrade, and every attempt logs the warning below. Giving up
+        // after a few tries would hide the problem and leave the records half converted, which is the
+        // outcome this guard exists to prevent.
+        if (static::hasPendingMigrations()) {
+            Logger::warning('Migrations are not finished, so the registered module version stays as it is.', [
+                'module'  => $name,
+                'version' => $version,
+            ]);
+
+            return false;
+        }
+
         $result = parent::upgradeModuleVersion($name, $version);
 
         try {
@@ -92,6 +111,28 @@ trait HasModuleUpgradeOverrides
         $fileSystem->put(static::getUpgradeFileName(), strtr($content, [
             '__VERSION__' => str_replace(['.', '-', '+'], '_', static::getVersionFromComposer()),
         ]));
+    }
+
+    /**
+     * Whether the installer still has migrations to run.
+     *
+     * Answers false when it cannot tell. An installer that stays silent must not keep the module
+     * upgradable for ever, and a PDK without this check behaves as it always did.
+     *
+     * @return bool
+     */
+    private static function hasPendingMigrations(): bool
+    {
+        try {
+            return (bool) Installer::hasPendingMigrations();
+        } catch (Throwable $e) {
+            Logger::error("Could not read pending migrations: {$e->getMessage()}", [
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+
+            return false;
+        }
     }
 
     /**

--- a/tests/Mock/MockPendingMigrationsInstaller.php
+++ b/tests/Mock/MockPendingMigrationsInstaller.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop\Tests\Mock;
+
+use MyParcelNL\Pdk\App\Installer\Contract\InstallerServiceInterface;
+
+/**
+ * Reports whatever a test wants about pending migrations.
+ *
+ * The real installer answers this from the applied-migrations list, which needs a full upgrade run to
+ * populate. A test that only cares what the module does with the answer sets it directly.
+ */
+final class MockPendingMigrationsInstaller implements InstallerServiceInterface
+{
+    /**
+     * @var bool
+     */
+    public static $pending = false;
+
+    public static function reset(): void
+    {
+        self::$pending = false;
+    }
+
+    public function hasPendingMigrations(): bool
+    {
+        return self::$pending;
+    }
+
+    public function install(...$args): void
+    {
+        // Nothing to install: this stands in for the installer only to answer the pending check.
+    }
+
+    public function uninstall(...$args): void
+    {
+        // Nothing to uninstall, same reason.
+    }
+}

--- a/tests/Mock/MockPsModule.php
+++ b/tests/Mock/MockPsModule.php
@@ -23,6 +23,13 @@ abstract class MockPsModule extends BaseMock implements StaticMockInterface
     protected static $instances = [];
 
     /**
+     * Records the version writes, so a test can tell whether the module bumped its registered version.
+     *
+     * @var array<string, string>
+     */
+    protected static $registeredVersions = [];
+
+    /**
      * @var \DI\Container
      */
     public $container;
@@ -67,7 +74,8 @@ abstract class MockPsModule extends BaseMock implements StaticMockInterface
 
     public static function reset(): void
     {
-        static::$instances = [];
+        static::$instances          = [];
+        static::$registeredVersions = [];
     }
 
     /**
@@ -94,6 +102,28 @@ abstract class MockPsModule extends BaseMock implements StaticMockInterface
      */
     protected static function loadUpgradeVersionList($module_name, $module_version, $registered_version)
     {
+        return true;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getRegisteredVersions(): array
+    {
+        return static::$registeredVersions;
+    }
+
+    /**
+     * @param  string $name
+     * @param  string $version
+     *
+     * @return bool
+     * @see \ModuleCore::upgradeModuleVersion()
+     */
+    public static function upgradeModuleVersion($name, $version): bool
+    {
+        static::$registeredVersions[$name] = $version;
+
         return true;
     }
 

--- a/tests/Unit/UpgradeAvailabilityTest.php
+++ b/tests/Unit/UpgradeAvailabilityTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\PrestaShop;
+
+use MyParcelNL;
+use MyParcelNL\Pdk\App\Installer\Contract\InstallerServiceInterface;
+use MyParcelNL\PrestaShop\Tests\Mock\MockPendingMigrationsInstaller;
+use MyParcelNL\PrestaShop\Tests\Mock\MockPsModule;
+use MyParcelNL\PrestaShop\Tests\Uses\UsesMockPsPdkInstance;
+use function DI\get;
+use function expect;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPsPdkInstance([
+    InstallerServiceInterface::class => get(MockPendingMigrationsInstaller::class),
+]));
+
+beforeEach(function () {
+    MockPendingMigrationsInstaller::reset();
+});
+
+it('leaves the registered version behind while migrations are pending', function () {
+    // canBeUpgraded() compares the registered version with the one on disk, so leaving it behind is
+    // what keeps PrestaShop offering the upgrade. Bumping it would hide the button and strand
+    // whatever is left unconverted.
+    MockPendingMigrationsInstaller::$pending = true;
+
+    $result = MyParcelNL::upgradeModuleVersion(MyParcelNL::MODULE_NAME, '9.9.9');
+
+    expect($result)->toBeFalse()
+        ->and(MockPsModule::getRegisteredVersions())->not->toHaveKey(MyParcelNL::MODULE_NAME);
+});
+
+it('records the registered version once nothing is pending', function () {
+    MockPendingMigrationsInstaller::$pending = false;
+
+    $result = MyParcelNL::upgradeModuleVersion(MyParcelNL::MODULE_NAME, '9.9.9');
+
+    expect($result)->toBeTrue()
+        ->and(MockPsModule::getRegisteredVersions())->toHaveKey(MyParcelNL::MODULE_NAME);
+});


### PR DESCRIPTION
keeps the PrestaShop module upgrade available until every pending migration has finished.

PrestaShop offers the upgrade while the registered module version is behind the one on disk, and `upgradeModuleVersion()` wrote the new version as soon as the upgrade ran. A migration that reported failure therefore lost its trigger: the upgrade disappeared from the module manager, and the records it had not converted stayed as they were until the next release.

The registered version now stays as it is while the installer reports pending migrations, so a merchant can run the upgrade again and the migration continues where it stopped. There is no cap on the attempts, on purpose: a shop that cannot finish keeps being offered the upgrade and logs a warning each time, rather than quietly settling for half-converted records.

The pending check answers false when it cannot tell. A PDK without the check behaves as it always did, so this can ship before the PDK side, and an installer that cannot answer never leaves the module upgradable for ever.

Depends on the PDK half of INT-1816, which makes the installer report pending migrations. Until that releases, this change is inert.

Refs INT-1816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
